### PR TITLE
build(linters): add SlevomatCodingStandard and fix type declarations [RSRMID-2787]

### DIFF
--- a/.github/linters/phpcs.xml
+++ b/.github/linters/phpcs.xml
@@ -1,11 +1,70 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<ruleset name="super-linter">
-    <description>The default coding standard for usage with GitHub Super-Linter. It just includes PSR12.</description>
+<ruleset name="php-sdk">
+    <description>PSR-12 with SlevomatCodingStandard rules for modern PHP.</description>
+
     <!-- Use PSR-12 as a base -->
-    <rule ref="PSR12"/>
+    <rule ref="PSR12">
+        <!-- Allow declare(strict_types=1) before file-level docblock (Slevomat handles this) -->
+        <exclude name="PSR12.Files.FileHeader.IncorrectOrder"/>
+    </rule>
+
     <arg value="s"/>
     <arg value="q"/>
     <arg value="n"/>
     <arg name="colors"/>
+
+    <!-- Require strict types declaration -->
+    <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
+        <properties>
+            <property name="spacesCountAroundEqualsSign" value="0"/>
+        </properties>
+    </rule>
+
+    <!-- Unused imports -->
+    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
+        <properties>
+            <property name="searchAnnotations" value="true"/>
+        </properties>
+    </rule>
+
+    <!-- Require fully qualified exceptions/functions/constants in global namespace -->
+    <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
+        <properties>
+            <property name="allowFullyQualifiedGlobalClasses" value="true"/>
+            <property name="allowFullyQualifiedGlobalFunctions" value="true"/>
+            <property name="allowFullyQualifiedGlobalConstants" value="true"/>
+            <property name="searchAnnotations" value="true"/>
+        </properties>
+    </rule>
+
+    <!-- Require use statements sorted alphabetically -->
+    <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses"/>
+
+    <!-- Require typed properties -->
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint"/>
+
+    <!-- Require return type hints -->
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint"/>
+
+    <!-- Require parameter type hints -->
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint"/>
+
+    <!-- Forbid useless parentheses -->
+    <rule ref="SlevomatCodingStandard.PHP.UselessParentheses"/>
+
+    <!-- Forbid useless semicolons -->
+    <rule ref="SlevomatCodingStandard.PHP.UselessSemicolon"/>
+
+    <!-- Require null coalescing operator when possible -->
+    <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator"/>
+
+    <!-- Use short list syntax -->
+    <rule ref="SlevomatCodingStandard.PHP.ShortList"/>
+
+    <!-- Require use of null safe operator -->
+    <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullSafeObjectOperator"/>
+
+    <!-- Forbid superfluous @var inline annotations -->
+    <rule ref="SlevomatCodingStandard.PHP.RequireExplicitAssertion"/>
 </ruleset>

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
     "phpstan/phpstan": "^2.0",
     "phpstan/extension-installer": "^1.4",
     "rector/rector": "^2.0",
-    "vimeo/psalm": "^6.0"
+    "vimeo/psalm": "^6.0",
+    "slevomat/coding-standard": "^8.0"
   },
   "autoload": {
     "psr-4": {
@@ -76,7 +77,8 @@
   },
   "config": {
     "allow-plugins": {
-      "phpstan/extension-installer": true
+      "phpstan/extension-installer": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
     }
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "12fb993017efe9ab2cd506d620f46f15",
+    "content-hash": "fbe6bc4239326993a3eec44840ff824a",
     "packages": [
         {
             "name": "centralnic-reseller/idn-converter",
@@ -1196,6 +1196,102 @@
                 "source": "https://github.com/DaveRandom/LibDNS/tree/v2.1.0"
             },
             "time": "2024-04-12T12:12:48+00:00"
+        },
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.2",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.2",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^9.0 || ^10.0.0@dev",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "opensource@frenck.dev",
+                    "homepage": "https://frenck.dev",
+                    "role": "Open source developer"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-05-06T08:26:05+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -4035,6 +4131,71 @@
                 }
             ],
             "time": "2024-10-09T05:16:32+00:00"
+        },
+        {
+            "name": "slevomat/coding-standard",
+            "version": "8.29.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "81fce13c4ef4b53a03e5cfa6ce36afc191c1598e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/81fce13c4ef4b53a03e5cfa6ce36afc191c1598e",
+                "reference": "81fce13c4ef4b53a03e5cfa6ce36afc191c1598e",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.2.1",
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpdoc-parser": "^2.3.2",
+                "squizlabs/php_codesniffer": "^4.0.1"
+            },
+            "require-dev": {
+                "phing/phing": "3.0.1|3.1.2",
+                "php-parallel-lint/php-parallel-lint": "1.4.0",
+                "phpstan/phpstan": "2.1.54",
+                "phpstan/phpstan-deprecation-rules": "2.0.4",
+                "phpstan/phpstan-phpunit": "2.0.16",
+                "phpstan/phpstan-strict-rules": "2.0.11",
+                "phpunit/phpunit": "9.6.34|10.5.63|11.4.4|11.5.55|12.5.24"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "keywords": [
+                "dev",
+                "phpcs"
+            ],
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/8.29.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-07T05:48:08+00:00"
         },
         {
             "name": "spatie/array-to-xml",

--- a/src/CNR/Client.php
+++ b/src/CNR/Client.php
@@ -1,6 +1,6 @@
 <?php
 
-#declare(strict_types=1);
+declare(strict_types=1);
 
 /**
  * CNIC\CNR
@@ -9,11 +9,12 @@
 
 namespace CNIC\CNR;
 
-use CNIC\CommandFormatter;
 use CNIC\CNR\Logger as L;
-use CNIC\CNR\SocketConfig;
 use CNIC\CNR\Response;
+use CNIC\CNR\SocketConfig;
+use CNIC\CommandFormatter;
 use CNIC\IDNA\Factory\ConverterFactory;
+use CNIC\LoggerInterface;
 
 /**
  * CNR API Client
@@ -32,25 +33,22 @@ class Client
      * registrar api settings
      * @var array<mixed>
      */
-    public $settings;
+    public array $settings;
 
     /**
      * API connection url
-     * @var string
      */
-    protected $socketURL;
+    protected string $socketURL;
 
     /**
      * Object covering API connection data
-     * @var SocketConfig
      */
-    protected $socketConfig;
+    protected SocketConfig $socketConfig;
 
     /**
      * activity flag for debug mode
-     * @var boolean
      */
-    protected $debugMode;
+    protected bool $debugMode;
 
     /**
      * user agent
@@ -61,32 +59,29 @@ class Client
      * additional curl options to use
      * @var array<string>
      */
-    protected $curlopts = [];
+    protected array $curlopts = [];
 
     /**
      * logger function name for debug mode
-     * @var \CNIC\LoggerInterface
      */
-    protected $logger;
+    protected LoggerInterface $logger;
 
     /**
      * is connected to OT&E
-     * @var bool
      */
-    public $isOTE = false;
+    public bool $isOTE = false;
 
     /**
      * curl handle cache
-     * @var \CurlHandle|null
      */
-    protected $chandle;
+    protected ?\CurlHandle $chandle = null;
 
     /**
      * Constructor
      *
      * @param string $path Path to the configuration file
      */
-    public function __construct($path = "")
+    public function __construct(string $path = "")
     {
         $contents = file_get_contents($path);
         if ($contents === false) {
@@ -108,10 +103,9 @@ class Client
     /**
      * set custom logger to use instead of default one
      * create your own class implementing \CNIC\LoggerInterface
-     * @param \CNIC\LoggerInterface $customLogger
      * @return $this
      */
-    public function setCustomLogger($customLogger)
+    public function setCustomLogger(LoggerInterface $customLogger)
     {
         $this->logger = $customLogger;
         return $this;
@@ -151,18 +145,16 @@ class Client
      * Serialize given command for POST request including connection configuration data
      * @param array<string,mixed> $cmd API command to encode
      * @param bool $secured secure password (when used for output)
-     * @return string
      */
-    public function getPOSTData($cmd, $secured = false)
+    public function getPOSTData(array $cmd, bool $secured = false): string
     {
         return $this->socketConfig->getPOSTData($cmd, $secured);
     }
 
     /**
      * Get the API Session ID that is currently set
-     * @return string|null
      */
-    public function getSession()
+    public function getSession(): ?string
     {
         $sessid = $this->socketConfig->getSession();
         return ($sessid === "" ? null : $sessid);
@@ -170,9 +162,8 @@ class Client
 
     /**
      * Get the API connection url that is currently set
-     * @return string
      */
-    public function getURL()
+    public function getURL(): string
     {
         return $this->socketURL;
     }
@@ -184,19 +175,17 @@ class Client
      * @param array<string> $modules further modules to add to user agent string, format: ["<module1>/<version>", "<module2>/<version>", ... ]
      * @return $this
      */
-    public function setUserAgent($str, $rv, $modules = [])
+    public function setUserAgent(string $str, string $rv, array $modules = [])
     {
-        $mods = empty($modules) ? "" : " " . implode(" ", $modules);
-        $this->ua = ($str . " (" . PHP_OS . "; " . php_uname("m") . "; rv:" . $rv . ")" . $mods . " php-sdk/" . $this->getVersion() . " php/" . implode(".", [PHP_MAJOR_VERSION, PHP_MINOR_VERSION, PHP_RELEASE_VERSION])
-        );
+        $mods = $modules === [] ? "" : " " . implode(" ", $modules);
+        $this->ua = $str . " (" . PHP_OS . "; " . php_uname("m") . "; rv:" . $rv . ")" . $mods . " php-sdk/" . $this->getVersion() . " php/" . implode(".", [PHP_MAJOR_VERSION, PHP_MINOR_VERSION, PHP_RELEASE_VERSION]);
         return $this;
     }
 
     /**
      * Get the user agent string
-     * @return string
      */
-    public function getUserAgent()
+    public function getUserAgent(): string
     {
         if ($this->ua === '') {
             $this->ua = "PHP-SDK (" . PHP_OS . "; " . php_uname("m") . "; rv:" . $this->getVersion() . ") php/" . implode(".", [PHP_MAJOR_VERSION, PHP_MINOR_VERSION, PHP_RELEASE_VERSION]);
@@ -209,9 +198,9 @@ class Client
      * @param string $proxy proxy to use (optional, for reset)
      * @return $this
      */
-    public function setProxy($proxy = "")
+    public function setProxy(string $proxy = "")
     {
-        if (empty($proxy)) {
+        if ($proxy === '' || $proxy === '0') {
             unset($this->curlopts[CURLOPT_PROXY]);
         } else {
             $this->curlopts[CURLOPT_PROXY] = $proxy;
@@ -221,9 +210,8 @@ class Client
 
     /**
      * Get proxy configuration for API communication
-     * @return string|null
      */
-    public function getProxy()
+    public function getProxy(): ?string
     {
         if (isset($this->curlopts[CURLOPT_PROXY])) {
             return $this->curlopts[CURLOPT_PROXY];
@@ -236,9 +224,9 @@ class Client
      * @param string $referer Referer (optional, for reset)
      * @return $this
      */
-    public function setReferer($referer = "")
+    public function setReferer(string $referer = "")
     {
-        if (empty($referer)) {
+        if ($referer === '' || $referer === '0') {
             unset($this->curlopts[CURLOPT_REFERER]);
         } else {
             $this->curlopts[CURLOPT_REFERER] = $referer;
@@ -248,9 +236,8 @@ class Client
 
     /**
      * Get Referer configuration for API communication
-     * @return string|null
      */
-    public function getReferer()
+    public function getReferer(): ?string
     {
         if (isset($this->curlopts[CURLOPT_REFERER])) {
             return $this->curlopts[CURLOPT_REFERER];
@@ -260,9 +247,8 @@ class Client
 
     /**
      * Get the current module version
-     * @return string
      */
-    public function getVersion()
+    public function getVersion(): string
     {
         return "14.0.0";
     }
@@ -272,7 +258,7 @@ class Client
      * @param string $value API connection url to set
      * @return $this
      */
-    public function setURL($value)
+    public function setURL(string $value)
     {
         $this->socketURL = $value;
         return $this;
@@ -283,7 +269,7 @@ class Client
      * @param string $value API session id (optional, for reset)
      * @return $this
      */
-    public function setSession($value = "")
+    public function setSession(string $value = "")
     {
         $this->socketConfig->setSession($value);
         return $this;
@@ -296,9 +282,9 @@ class Client
      * @throws \Exception in case this feature is unsupported
      * @return $this
      */
-    public function setRemoteIPAddress($value = "")
+    public function setRemoteIPAddress(string $value = "")
     {
-        if (!empty($value) && !isset($this->settings["parameters"]["ipfilter"])) {
+        if ($value !== '' && $value !== '0' && !isset($this->settings["parameters"]["ipfilter"])) {
             throw new \Exception("Feature `IP Filter` not supported");
         }
         $this->socketConfig->setRemoteAddress($value);
@@ -311,7 +297,7 @@ class Client
      * @param string $pw account password (optional, for reset)
      * @return $this
      */
-    public function setCredentials($uid = "", $pw = "")
+    public function setCredentials(string $uid = "", string $pw = "")
     {
         $this->socketConfig->setLogin($uid);
         $this->socketConfig->setPassword($pw);
@@ -325,10 +311,10 @@ class Client
      * @param string $pw role user password (optional, for reset)
      * @return $this
      */
-    public function setRoleCredentials($uid = "", $role = "", $pw = "")
+    public function setRoleCredentials(string $uid = "", string $role = "", string $pw = "")
     {
         $login = $uid;
-        if (!empty($role)) {
+        if ($role !== '' && $role !== '0') {
             $login .= $this->settings["roleSeparator"] . $role;
         }
         return $this->setCredentials($login, $pw);
@@ -339,7 +325,7 @@ class Client
      * @param array<string> $domains list of domain names (or tlds)
      * @return array<mixed>
      */
-    public function IDNConvert($domains)
+    public function IDNConvert(array $domains): array
     {
         return ConverterFactory::convert($domains);
     }
@@ -350,7 +336,7 @@ class Client
      * @param array<string> $cmd API command
      * @return array<string>
      */
-    protected function autoIDNConvert($cmd)
+    protected function autoIDNConvert(array $cmd): array
     {
         // only convert if configured for the registrar
         // and ignore commands in string format (even deprecated)
@@ -395,9 +381,8 @@ class Client
     /**
      * Perform API request using the given command
      * @param array<mixed> $cmd API command to request (optional for session login)
-     * @return Response
      */
-    public function request(array $cmd = [])
+    public function request(array $cmd = []): Response
     {
         // flatten nested api command bulk parameters and sort them
         $mycmd = CommandFormatter::flattenCommand($cmd);
@@ -409,7 +394,7 @@ class Client
         ];
         $data = $this->getPOSTData($mycmd);
 
-        if (!$this->chandle) {
+        if (!$this->chandle instanceof \CurlHandle) {
             $tmp = curl_init();
             if ($tmp === false) {
                 $r = new Response("nocurl", $mycmd, $cfg, $this->context);
@@ -440,9 +425,8 @@ class Client
             ]
         ] + $this->curlopts);
 
-        // which is by default tested for by phpStan
-        /** @var string|false $r */
         $r = curl_exec($this->chandle);
+        \assert(\is_string($r) || $r === false);
         $error = null;
         if ($r === false) {
             $error = curl_error($this->chandle);
@@ -461,9 +445,8 @@ class Client
      * Useful for tables
      * @param Response $rr API Response of current page
      * @throws \Exception in case Command Parameter LAST is in use while using this method
-     * @return Response|null
      */
-    public function requestNextResponsePage($rr)
+    public function requestNextResponsePage(Response $rr): ?Response
     {
         $mycmd = $rr->getCommand();
         if (array_key_exists("LAST", $mycmd)) {
@@ -490,7 +473,7 @@ class Client
      * @param array<string,mixed> $cmd API list command to use
      * @return Response[]
      */
-    public function requestAllResponsePages($cmd)
+    public function requestAllResponsePages(array $cmd): array
     {
         $responses = [];
         $rr = $this->request(array_merge([], $cmd, ["FIRST" => 0]));
@@ -499,15 +482,14 @@ class Client
         do {
             $responses[$idx++] = $tmp;
             $tmp = $this->requestNextResponsePage($tmp);
-        } while ($tmp !== null);
+        } while ($tmp instanceof Response);
         return $responses;
     }
 
     /**
      * Close all curl handles
-     * @return void
      */
-    public function close()
+    public function close(): void
     {
         if (!is_null($this->chandle)) {
             curl_close($this->chandle);
@@ -519,7 +501,7 @@ class Client
      * @param string $uid subuser account name
      * @return $this
      */
-    public function setUserView($uid = "")
+    public function setUserView(string $uid = "")
     {
         $this->socketConfig->setUser($uid);
         return $this;

--- a/src/CNR/Column.php
+++ b/src/CNR/Column.php
@@ -1,6 +1,6 @@
 <?php
 
-#declare(strict_types=1);
+declare(strict_types=1);
 
 /**
  * CNIC\CNR
@@ -19,21 +19,19 @@ class Column // implements \CNIC\ColumnInterface
 {
     /**
      * count of column data entries
-     * @var int
      */
-    public $length;
+    public int $length;
 
     /**
      * column key name
-     * @var string
      */
-    private $key;
+    private string $key;
 
     /**
      * column data container
      * @var string[]
      */
-    private $data;
+    private array $data;
 
     /**
      * Constructor
@@ -41,7 +39,7 @@ class Column // implements \CNIC\ColumnInterface
      * @param string $key Column Name
      * @param string[] $data Column Data
      */
-    public function __construct($key, $data)
+    public function __construct(string $key, array $data)
     {
         $this->key = $key;
         $this->data = $data;
@@ -50,9 +48,8 @@ class Column // implements \CNIC\ColumnInterface
 
     /**
      * Get column name
-     * @return string
      */
-    public function getKey()
+    public function getKey(): string
     {
         return $this->key;
     }
@@ -61,7 +58,7 @@ class Column // implements \CNIC\ColumnInterface
      * Get column data
      * @return string[]
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->data;
     }
@@ -69,9 +66,8 @@ class Column // implements \CNIC\ColumnInterface
     /**
      * Get column data at given index
      * @param integer $idx data index
-     * @return string|null
      */
-    public function getDataByIndex($idx)
+    public function getDataByIndex(int $idx): mixed
     {
         return $this->hasDataIndex($idx) ? $this->data[$idx] : null;
     }
@@ -79,9 +75,8 @@ class Column // implements \CNIC\ColumnInterface
     /**
      * Check if column has a given data index
      * @param integer $idx data index
-     * @return bool
      */
-    private function hasDataIndex($idx)
+    private function hasDataIndex(int $idx): bool
     {
         return ($idx >= 0 && $idx < $this->length);
     }

--- a/src/CNR/Logger.php
+++ b/src/CNR/Logger.php
@@ -2,33 +2,36 @@
 
 declare(strict_types=1);
 
-#declare(strict_types=1);
 /**
  * CNIC\CNR
  * Copyright © CentralNic Group PLC
  */
+
 namespace CNIC\CNR;
+
+use CNIC\CNR\Response;
+use CNIC\LoggerInterface;
 
 /**
  * CNR Logger
  *
  * @package CNIC\CNR
  */
-final class Logger implements \CNIC\LoggerInterface
+final class Logger implements LoggerInterface
 {
     /**
      * output/log given data
      * @param string $post post request data in string format
-     * @param \CNIC\CNR\Response $r Response to log
+     * @param Response $r Response to log
      * @param string|null $error error message (optional)
      */
     #[\Override]
-    public function log($post, \CNIC\CNR\Response $r, ?string $error = null): void
+    public function log($post, Response $r, ?string $error = null): void
     {
          echo implode("\n", [
             print_r($r->getCommand(), true),
             $post,
-            ($error !== null && $error !== '') ? "HTTP communication failed: " . $error : "",
+            $error !== null && $error !== '' ? "HTTP communication failed: " . $error : "",
             $r->getPlain()
          ]);
     }

--- a/src/CNR/Record.php
+++ b/src/CNR/Record.php
@@ -1,6 +1,6 @@
 <?php
 
-#declare(strict_types=1);
+declare(strict_types=1);
 
 /**
  * CNIC\CNR
@@ -27,9 +27,9 @@ class Record // implements \CNIC\RecordInterface
      *   // ... further column data ...
      * ];
      * </code>
-     * @var array<string>
+     * @var array<string,mixed>
      */
-    private $data;
+    private array $data;
 
     /**
      * Constructor
@@ -41,18 +41,18 @@ class Record // implements \CNIC\RecordInterface
      *   // ... further column data ...
      * ];
      * </code>
-     * @param array<string> $data data object
+     * @param array<string,mixed> $data data object
      */
-    public function __construct($data)
+    public function __construct(array $data)
     {
         $this->data = $data;
     }
 
     /**
      * get row data
-     * @return array<string>
+     * @return array<string,mixed>
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->data;
     }
@@ -60,9 +60,8 @@ class Record // implements \CNIC\RecordInterface
     /**
      * get row data for given column
      * @param string $key column name
-     * @return string|null
      */
-    public function getDataByKey($key)
+    public function getDataByKey(string $key): mixed
     {
         if ($this->hasData($key)) {
             return $this->data[$key];
@@ -73,9 +72,8 @@ class Record // implements \CNIC\RecordInterface
     /**
      * check if record has data for given column
      * @param string $key column name
-     * @return bool
      */
-    private function hasData($key)
+    private function hasData(string $key): bool
     {
         return array_key_exists($key, $this->data);
     }

--- a/src/CNR/Response.php
+++ b/src/CNR/Response.php
@@ -1,6 +1,6 @@
 <?php
 
-#declare(strict_types=1);
+declare(strict_types=1);
 
 /**
  * CNIC\CNR
@@ -9,6 +9,7 @@
 
 namespace CNIC\CNR;
 
+use CNIC\CNR\Column;
 use CNIC\CNR\ResponseParser as RP;
 use CNIC\CNR\ResponseTranslator as RT;
 use CNIC\CommandFormatter;
@@ -25,61 +26,58 @@ class Response // implements \CNIC\ResponseInterface
      * The API Command used within this request
      * @var array<string>
      */
-    protected $command;
+    protected array $command;
 
     /**
      * plain API response
-     * @var string
      */
-    protected $raw;
+    protected string $raw;
 
     /**
      * hash representation of plain API response
      * @var array<string,mixed>
      */
-    protected $hash;
+    protected array $hash;
 
     /**
      * Regex for pagination related column keys
      * @var non-empty-string
      */
-    protected $paginationkeys = "/^TOTAL|COUNT|LIMIT|FIRST|LAST$/";
+    protected string $paginationkeys = "/^TOTAL|COUNT|LIMIT|FIRST|LAST$/";
 
     /**
      * Column names available in this response
      * @var string[]
      */
-    protected $columnkeys;
+    protected array $columnkeys;
 
     /**
      * Container of Column Instances
      * @var Column[]
      */
-    protected $columns;
+    protected array $columns;
 
     /**
      * Record Index we currently point to in record list
-     * @var int
      */
-    protected $recordIndex;
+    protected int $recordIndex;
 
     /**
      * Record List (List of rows)
      * @var Record[]
      */
-    protected $records;
+    protected array $records;
 
     /**
      * Context data for the response
      * @var array<string,mixed>
      */
-    protected $context;
+    protected array $context;
 
     /**
      * API request url
-     * @var string
      */
-    protected $requestUrl = "";
+    protected string $requestUrl = "";
 
     /**
      * Constructor
@@ -88,7 +86,7 @@ class Response // implements \CNIC\ResponseInterface
      * @param array<string> $ph placeholder array to get vars in response description dynamically replaced
      * @param array<string,mixed> $context context data for the response (for use in custom loggers etc., optional, has no impact on SDK behaviour)
      */
-    public function __construct($raw, $cmd = [], $ph = [], $context = [])
+    public function __construct(string $raw, array $cmd = [], array $ph = [], array $context = [])
     {
         if (isset($cmd["PASSWORD"])) { // make password no longer accessible
             $cmd["PASSWORD"] = "***";
@@ -120,8 +118,9 @@ class Response // implements \CNIC\ResponseInterface
             for ($i = 0; $i < $count; $i++) {
                 $d = [];
                 foreach ($colKeys as $k) {
+                    $k .= "";
                     $col = $this->getColumn($k);
-                    if ($col) {
+                    if ($col instanceof Column) {
                         $v = $col->getDataByIndex($i);
                         if ($v !== null) {
                             $d[$k] = $v;
@@ -137,52 +136,47 @@ class Response // implements \CNIC\ResponseInterface
      * Get context data for the response
      * @return array<string,mixed>
      */
-    public function getContext()
+    public function getContext(): array
     {
         return $this->context;
     }
 
     /**
      * Get Request URL
-     * @return string
      */
-    public function getRequestURL()
+    public function getRequestURL(): string
     {
         return $this->requestUrl;
     }
 
     /**
      * Get API response code
-     * @return int
      */
-    public function getCode()
+    public function getCode(): int
     {
         return intval($this->hash["CODE"], 10);
     }
 
     /**
      * Get API response description
-     * @return string
      */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->hash["DESCRIPTION"];
     }
 
     /**
      * Get Plain API response
-     * @return string
      */
-    public function getPlain()
+    public function getPlain(): string
     {
         return $this->raw;
     }
 
     /**
      * Get Queuetime of API response
-     * @return float
      */
-    public function getQueuetime()
+    public function getQueuetime(): float
     {
         if (array_key_exists("QUEUETIME", $this->hash)) {
             return floatval($this->hash["QUEUETIME"]);
@@ -194,16 +188,15 @@ class Response // implements \CNIC\ResponseInterface
      * Get API response as Hash
      * @return array<mixed>
      */
-    public function getHash()
+    public function getHash(): array
     {
         return $this->hash;
     }
 
     /**
      * Get Runtime of API response
-     * @return float
      */
-    public function getRuntime()
+    public function getRuntime(): float
     {
         if (array_key_exists("RUNTIME", $this->hash)) {
             return floatval($this->hash["RUNTIME"]);
@@ -214,9 +207,8 @@ class Response // implements \CNIC\ResponseInterface
     /**
      * Check if current API response represents an error case
      * API response code is an 5xx code
-     * @return bool
      */
-    public function isError()
+    public function isError(): bool
     {
         return substr($this->hash["CODE"], 0, 1) === "5";
     }
@@ -224,9 +216,8 @@ class Response // implements \CNIC\ResponseInterface
     /**
      * Check if current API response represents a success case
      * API response code is an 2xx code
-     * @return bool
      */
-    public function isSuccess()
+    public function isSuccess(): bool
     {
         return substr($this->hash["CODE"], 0, 1) === "2";
     }
@@ -234,18 +225,16 @@ class Response // implements \CNIC\ResponseInterface
     /**
      * Check if current API response represents a temporary error case
      * API response code is an 4xx code
-     * @return bool
      */
-    public function isTmpError()
+    public function isTmpError(): bool
     {
         return substr($this->hash["CODE"], 0, 1) === "4";
     }
 
     /**
      * Check if current operation is returned as pending
-     * @return bool
      */
-    public function isPending()
+    public function isPending(): bool
     {
         return isset($this->hash["PENDING"]) && $this->hash["PENDING"] === "1";
     }
@@ -256,7 +245,7 @@ class Response // implements \CNIC\ResponseInterface
      * @param string[] $data array of column data
      * @return $this
      */
-    public function addColumn($key, $data)
+    public function addColumn(string $key, array $data)
     {
         $col = new Column($key, $data);
         $this->columns[] = $col;
@@ -266,10 +255,10 @@ class Response // implements \CNIC\ResponseInterface
 
     /**
      * Add a record to the record list
-     * @param array<string> $h row hash data
+     * @param array<string,mixed> $h row hash data
      * @return $this
      */
-    public function addRecord($h)
+    public function addRecord(array $h)
     {
         $this->records[] = new Record($h);
         return $this;
@@ -278,9 +267,8 @@ class Response // implements \CNIC\ResponseInterface
     /**
      * Get column by column name
      * @param string $key column name
-     * @return Column|null
      */
-    public function getColumn($key)
+    public function getColumn(string $key): ?Column
     {
         return ($this->hasColumn($key) ? $this->columns[array_search($key, $this->columnkeys)] : null);
     }
@@ -289,12 +277,11 @@ class Response // implements \CNIC\ResponseInterface
      * Get Data by Column Name and Index
      * @param string $colkey column name
      * @param int $index column data index
-     * @return string|null
      */
-    public function getColumnIndex($colkey, $index)
+    public function getColumnIndex(string $colkey, int $index): mixed
     {
         $col = $this->getColumn($colkey);
-        return $col ? $col->getDataByIndex($index) : null;
+        return $col instanceof Column ? $col->getDataByIndex($index) : null;
     }
 
     /**
@@ -302,7 +289,7 @@ class Response // implements \CNIC\ResponseInterface
      * @param bool $filterPaginationKeys strip pagination columns
      * @return string[]
      */
-    public function getColumnKeys($filterPaginationKeys = false)
+    public function getColumnKeys(bool $filterPaginationKeys = false): array
     {
         if ($filterPaginationKeys) {
             // Ensure that preg_grep always returns an array
@@ -316,7 +303,7 @@ class Response // implements \CNIC\ResponseInterface
      * Get List of Columns
      * @return Column[]
      */
-    public function getColumns()
+    public function getColumns(): array
     {
         return $this->columns;
     }
@@ -325,25 +312,23 @@ class Response // implements \CNIC\ResponseInterface
      * Get Command used in this request
      * @return array<string>
      */
-    public function getCommand()
+    public function getCommand(): array
     {
         return CommandFormatter::getSortedCommand($this->command);
     }
 
     /**
      * Get Command used in this request in plain text format
-     * @return string
      */
-    public function getCommandPlain()
+    public function getCommandPlain(): string
     {
         return CommandFormatter::formatCommand($this->getCommand());
     }
 
     /**
      * Get Page Number of current List Query
-     * @return int|null
      */
-    public function getCurrentPageNumber()
+    public function getCurrentPageNumber(): ?int
     {
         $first = $this->getFirstRecordIndex();
         $limit = $this->getRecordsLimitation();
@@ -355,25 +340,23 @@ class Response // implements \CNIC\ResponseInterface
 
     /**
      * Get Record of current record index
-     * @return Record|null
      */
-    public function getCurrentRecord()
+    public function getCurrentRecord(): ?Record
     {
         return $this->hasCurrentRecord() ? $this->records[$this->recordIndex] : null;
     }
 
     /**
      * Get Index of first row in this response
-     * @return int|null
      */
-    public function getFirstRecordIndex()
+    public function getFirstRecordIndex(): ?int
     {
         $col = $this->getColumn("FIRST");
-        if ($col) {
+        if ($col instanceof Column) {
             $f = $col->getDataByIndex(0);
             return $f === null ? 0 : intval($f, 10);
         }
-        if ($this->getRecordsCount()) {
+        if ($this->getRecordsCount() !== 0) {
             return 0;
         }
         return null;
@@ -381,19 +364,18 @@ class Response // implements \CNIC\ResponseInterface
 
     /**
      * Get last record index of the current list query
-     * @return int|null
      */
-    public function getLastRecordIndex()
+    public function getLastRecordIndex(): ?int
     {
         $col = $this->getColumn("LAST");
-        if ($col) {
+        if ($col instanceof Column) {
             $l = $col->getDataByIndex(0);
             if ($l !== null) {
                 return intval($l, 10);
             }
         }
         $c = $this->getRecordsCount();
-        if ($c) {
+        if ($c !== 0) {
             return $c - 1;
         }
         return null;
@@ -403,7 +385,7 @@ class Response // implements \CNIC\ResponseInterface
      * Get Response as List Hash including useful meta data for tables
      * @return array<mixed>
      */
-    public function getListHash()
+    public function getListHash(): array
     {
         $lh = [];
         foreach ($this->records as $rec) {
@@ -426,9 +408,8 @@ class Response // implements \CNIC\ResponseInterface
 
     /**
      * Get next record in record list
-     * @return Record|null
      */
-    public function getNextRecord()
+    public function getNextRecord(): ?Record
     {
         if ($this->hasNextRecord()) {
             return $this->records[++$this->recordIndex];
@@ -438,9 +419,8 @@ class Response // implements \CNIC\ResponseInterface
 
     /**
      * Get Page Number of next list query
-     * @return int|null
      */
-    public function getNextPageNumber()
+    public function getNextPageNumber(): ?int
     {
         $cp = $this->getCurrentPageNumber();
         if ($cp === null) {
@@ -453,9 +433,8 @@ class Response // implements \CNIC\ResponseInterface
 
     /**
      * Get the number of pages available for this list query
-     * @return int
      */
-    public function getNumberOfPages()
+    public function getNumberOfPages(): int
     {
         $t = $this->getRecordsTotalCount();
         $limit = $this->getRecordsLimitation();
@@ -469,7 +448,7 @@ class Response // implements \CNIC\ResponseInterface
      * Get object containing all paging data
      * @return array<string,int|null>
      */
-    public function getPagination()
+    public function getPagination(): array
     {
         return [
             "COUNT" => $this->getRecordsCount(),
@@ -486,9 +465,8 @@ class Response // implements \CNIC\ResponseInterface
 
     /**
      * Get Page Number of previous list query
-     * @return int|null
      */
-    public function getPreviousPageNumber()
+    public function getPreviousPageNumber(): ?int
     {
         $cp = $this->getCurrentPageNumber();
         if ($cp === null) {
@@ -503,9 +481,8 @@ class Response // implements \CNIC\ResponseInterface
 
     /**
      * Get previous record in record list
-     * @return Record|null
      */
-    public function getPreviousRecord()
+    public function getPreviousRecord(): ?Record
     {
         if ($this->hasPreviousRecord()) {
             return $this->records[--$this->recordIndex];
@@ -516,9 +493,8 @@ class Response // implements \CNIC\ResponseInterface
     /**
      * Get Record at given index
      * @param int $idx record index
-     * @return Record|null
      */
-    public function getRecord($idx)
+    public function getRecord(int $idx): ?Record
     {
         if ($idx >= 0 && $this->getRecordsCount() > $idx) {
             return $this->records[$idx];
@@ -530,28 +506,26 @@ class Response // implements \CNIC\ResponseInterface
      * Get all Records
      * @return Record[]
      */
-    public function getRecords()
+    public function getRecords(): array
     {
         return $this->records;
     }
 
     /**
      * Get count of rows in this response
-     * @return int
      */
-    public function getRecordsCount()
+    public function getRecordsCount(): int
     {
         return count($this->records);
     }
 
     /**
      * Get total count of records available for the list query
-     * @return int
      */
-    public function getRecordsTotalCount()
+    public function getRecordsTotalCount(): int
     {
         $col = $this->getColumn("TOTAL");
-        if ($col) {
+        if ($col instanceof Column) {
             $t = $col->getDataByIndex(0);
             if ($t !== null) {
                 return intval($t, 10);
@@ -563,12 +537,11 @@ class Response // implements \CNIC\ResponseInterface
     /**
      * Get limit(ation) setting of the current list query
      * This is the count of requested rows
-     * @return int
      */
-    public function getRecordsLimitation()
+    public function getRecordsLimitation(): int
     {
         $col = $this->getColumn("LIMIT");
-        if ($col) {
+        if ($col instanceof Column) {
             $l = $col->getDataByIndex(0);
             if ($l !== null) {
                 return intval($l, 10);
@@ -579,9 +552,8 @@ class Response // implements \CNIC\ResponseInterface
 
     /**
      * Check if this list query has a next page
-     * @return bool
      */
-    public function hasNextPage()
+    public function hasNextPage(): bool
     {
         $cp = $this->getCurrentPageNumber();
         if ($cp === null) {
@@ -592,15 +564,14 @@ class Response // implements \CNIC\ResponseInterface
 
     /**
      * Check if this list query has a previous page
-     * @return bool
      */
-    public function hasPreviousPage()
+    public function hasPreviousPage(): bool
     {
         $cp = $this->getCurrentPageNumber();
         if ($cp === null) {
             return false;
         }
-        return (($cp - 1) > 0);
+        return ($cp - 1 > 0);
     }
 
     /**
@@ -616,19 +587,17 @@ class Response // implements \CNIC\ResponseInterface
     /**
      * Check if column exists in response
      * @param string $key column name
-     * @return bool
      */
-    private function hasColumn($key)
+    private function hasColumn(string $key): bool
     {
-        return (in_array($key, $this->columnkeys));
+        return in_array($key, $this->columnkeys);
     }
 
     /**
      * Check if the record list contains a record for the
      * current record index in use
-     * @return bool
      */
-    private function hasCurrentRecord()
+    private function hasCurrentRecord(): bool
     {
         $len = $this->getRecordsCount();
         return (
@@ -641,9 +610,8 @@ class Response // implements \CNIC\ResponseInterface
     /**
      * Check if the record list contains a next record for the
      * current record index in use
-     * @return bool
      */
-    private function hasNextRecord()
+    private function hasNextRecord(): bool
     {
         $next = $this->recordIndex + 1;
         return ($this->hasCurrentRecord() && ($next < $this->getRecordsCount()));
@@ -652,9 +620,8 @@ class Response // implements \CNIC\ResponseInterface
     /**
      * Check if the record list contains a previous record for the
      * current record index in use
-     * @return bool
      */
-    private function hasPreviousRecord()
+    private function hasPreviousRecord(): bool
     {
         return ($this->recordIndex > 0 && $this->hasCurrentRecord());
     }

--- a/src/CNR/ResponseParser.php
+++ b/src/CNR/ResponseParser.php
@@ -1,6 +1,6 @@
 <?php
 
-#declare(strict_types=1);
+declare(strict_types=1);
 
 /**
  * CNIC\CNR
@@ -22,7 +22,7 @@ final class ResponseParser
      * @param string $raw API plain response
      * @return array<string,mixed>
      */
-    public static function parse($raw)
+    public static function parse(string $raw): array
     {
         /** @var array<string,mixed> $hash */
         $hash = [];

--- a/src/CNR/ResponseTemplateManager.php
+++ b/src/CNR/ResponseTemplateManager.php
@@ -1,6 +1,6 @@
 <?php
 
-#declare(strict_types=1);
+declare(strict_types=1);
 
 /**
  * CNIC\CNR
@@ -24,7 +24,7 @@ final class ResponseTemplateManager
      * Template container
      * @var array<string>
      */
-    public static $templates = [
+    public static array $templates = [
         "404" => "[RESPONSE]\r\nCODE=421\r\nDESCRIPTION=Page not found\r\nEOF\r\n",
         "500" => "[RESPONSE]\r\nCODE=500\r\nDESCRIPTION=Internal server error\r\nEOF\r\n",
         "empty" => "[RESPONSE]\r\nCODE=423\r\nDESCRIPTION=Empty API response. Probably unreachable API end point {CONNECTION_URL}\r\nEOF\r\n",
@@ -41,9 +41,8 @@ final class ResponseTemplateManager
      * Generate API response template string for given code and description
      * @param string $code API response code
      * @param string $description API response description
-     * @return string
      */
-    public static function generateTemplate($code, $description)
+    public static function generateTemplate(string $code, string $description): string
     {
         return "[RESPONSE]\r\nCODE=" . $code . "\r\nDESCRIPTION=" . $description . "\r\nEOF\r\n";
     }
@@ -53,9 +52,8 @@ final class ResponseTemplateManager
      * @param string $id template id
      * @param string $plain API plain response or API response code (when providing $descr)
      * @param string|null $descr API response description (optional)
-     * @return self
      */
-    public static function addTemplate(string $id, string $plain, ?string $descr = null)
+    public static function addTemplate(string $id, string $plain, ?string $descr = null): self
     {
         self::$templates[$id] = is_null($descr) ? $plain : self::generateTemplate($plain, $descr);
         return new self();
@@ -64,9 +62,8 @@ final class ResponseTemplateManager
     /**
      * Get response template instance from template container
      * @param string $id template id
-     * @return Response
      */
-    public static function getTemplate($id)
+    public static function getTemplate(string $id): Response
     {
         if (self::hasTemplate($id)) {
             return new Response($id);
@@ -78,7 +75,7 @@ final class ResponseTemplateManager
      * Return all available response templates
      * @return array<mixed>
      */
-    public static function getTemplates()
+    public static function getTemplates(): array
     {
         $tpls = [];
         foreach (self::$templates as $key => $raw) {
@@ -90,9 +87,8 @@ final class ResponseTemplateManager
     /**
      * Check if given template exists in template container
      * @param string $id template id
-     * @return bool
      */
-    public static function hasTemplate($id)
+    public static function hasTemplate(string $id): bool
     {
         return array_key_exists($id, self::$templates);
     }
@@ -101,9 +97,8 @@ final class ResponseTemplateManager
      * Check if given API response hash matches a given template by code and description
      * @param array<string> $tpl api response hash
      * @param string $id template id
-     * @return bool
      */
-    public static function isTemplateMatchHash($tpl, $id)
+    public static function isTemplateMatchHash(array $tpl, string $id): bool
     {
         $h = self::getTemplate($id)->getHash();
         return (
@@ -116,9 +111,8 @@ final class ResponseTemplateManager
      * Check if given API plain response matches a given template by code and description
      * @param string $plain API plain response
      * @param string $id template id
-     * @return bool
      */
-    public static function isTemplateMatchPlain($plain, $id)
+    public static function isTemplateMatchPlain(string $plain, string $id): bool
     {
         $h = self::getTemplate($id)->getHash();
         $tpl = RP::parse($plain);

--- a/src/CNR/ResponseTranslator.php
+++ b/src/CNR/ResponseTranslator.php
@@ -1,6 +1,6 @@
 <?php
 
-#declare(strict_types=1);
+declare(strict_types=1);
 
 /**
  * CNIC\CNR
@@ -22,7 +22,7 @@ final class ResponseTranslator
      * hidden class var of API description regex mappings for translation
      * @var array<mixed>
      */
-    private static $descriptionRegexMap = [
+    private static array $descriptionRegexMap = [
         // HX - just for future reference, can be cleaned up if we have something similar in place for CNR
         "Authorization failed; Operation forbidden by ACL" => "Authorization failed; Used Command `{COMMAND}` not white-listed by your Access Control List",
         // CNR
@@ -42,18 +42,17 @@ final class ResponseTranslator
      * @param string $raw API raw response
      * @param array<string> $cmd requested API command
      * @param array<string> $ph list of place holder vars
-     * @return string
      */
-    public static function translate($raw, $cmd, $ph = [])
+    public static function translate(string $raw, array $cmd, array $ph = []): string
     {
-        $newraw = empty($raw) ? "empty" : $raw;
+        $newraw = $raw === '' || $raw === '0' ? "empty" : $raw;
         // Hint: Empty API Response (replace {CONNECTION_URL} later)
 
         // curl error handling
         $httperror = "";
         $isHTTPError = substr($newraw, 0, 10) === "httperror|";
         if ($isHTTPError) {
-            list($newraw, $httperror) = explode("|", $newraw);
+            [$newraw, $httperror] = explode("|", $newraw);
         }
 
         // Explicit call for a static template
@@ -120,9 +119,8 @@ final class ResponseTranslator
      * @param string $newraw The input text where the match will be searched for and replacements applied.
      * @param string $val The value to be used in replacement if a match is found.
      * @param array<string> $cmd The command data containing replacements, if applicable.
-     * @return bool
      */
-    private static function findMatch($regex, &$newraw, $val, $cmd)
+    private static function findMatch(string $regex, string &$newraw, string $val, array $cmd): bool
     {
         // match the response for given description
         // NOTE: we match if the description starts with the given description
@@ -152,9 +150,8 @@ final class ResponseTranslator
      *
      * @param string $raw input response
      * @param array<string> $ph placeholder key-value pairs
-     * @return string
      */
-    protected static function replacePlaceholders($raw, $ph)
+    protected static function replacePlaceholders(string $raw, array $ph): string
     {
         $tmp = preg_replace_callback(
             '/^(description\s*=\s*)(.*)$/im',

--- a/src/CNR/SessionClient.php
+++ b/src/CNR/SessionClient.php
@@ -1,6 +1,6 @@
 <?php
 
-#declare(strict_types=1);
+declare(strict_types=1);
 
 /**
  * CNIC\CNR
@@ -8,6 +8,9 @@
  */
 
 namespace CNIC\CNR;
+
+use CNIC\CNR\Column;
+use CNIC\CNR\Response;
 
 /**
  * CNR Session API Client
@@ -34,15 +37,14 @@ class SessionClient extends Client
 
     /**
      * Perform API login to start session-based communication
-     * @return Response
      */
-    public function login()
+    public function login(): Response
     {
         $this->socketConfig->setPersistent(true);
         $rr = $this->request();
         if ($rr->isSuccess()) {
             $col = $rr->getColumn("SESSIONID");
-            $this->setSession($col ? $col->getData()[0] : "");
+            $this->setSession($col instanceof Column ? $col->getData()[0] : "");
         }
         $this->socketConfig->setPersistent(false);
         return $rr;
@@ -51,9 +53,8 @@ class SessionClient extends Client
     /**
      * Perform API logout to close API session in use
      *
-     * @return \CNIC\CNR\Response
      */
-    public function logout()
+    public function logout(): Response
     {
         $rr = $this->request(["COMMAND" => "StopSession"]);
         if ($rr->isSuccess()) {
@@ -69,7 +70,7 @@ class SessionClient extends Client
      * @param array<string,mixed> $session php session instance ($_SESSION)
      * @return $this
      */
-    public function saveSession(&$session)
+    public function saveSession(array &$session)
     {
         $session["socketcfg"] = [
             "login" => $this->socketConfig->getLogin(),
@@ -85,7 +86,7 @@ class SessionClient extends Client
      * @param array<string,mixed> $session php session object ($_SESSION)
      * @return $this
      */
-    public function reuseSession(&$session)
+    public function reuseSession(array &$session)
     {
         if (isset($session["socketcfg"]["login"], $session["socketcfg"]["session"])) {
             $this->setCredentials($session["socketcfg"]["login"]);

--- a/src/CNR/SocketConfig.php
+++ b/src/CNR/SocketConfig.php
@@ -1,6 +1,6 @@
 <?php
 
-#declare(strict_types=1);
+declare(strict_types=1);
 
 /**
  * CNIC\CNR
@@ -18,45 +18,39 @@ class SocketConfig
 {
     /**
      * Parameter to trigger creation of a backend session
-     * @var bool
      */
-    private $persistent = false;
+    private bool $persistent = false;
 
     /**
      * account name
-     * @var string
      */
-    protected $login = "";
+    protected string $login = "";
 
     /**
      * account password
-     * @var string
      */
-    protected $pw = "";
+    protected string $pw = "";
 
     /**
      * remote ip address (ip filter)
-     * @var string
      */
-    protected $remoteaddr = "";
+    protected string $remoteaddr = "";
 
     /**
      * API session id
-     * @var string
      */
-    protected $session = "";
+    protected string $session = "";
 
     /**
      * subuser account name (subuser specific data view)
-     * @var string
      */
-    protected $user = "";
+    protected string $user = "";
 
     /**
      * list of http request parameters
      * @var array<string>
      */
-    protected $parameters;
+    protected array $parameters;
 
     /**
      * Constructor
@@ -73,7 +67,7 @@ class SocketConfig
      * @param bool $secured if password has to be returned "hidden"
      * @return array<string,string>
      */
-    protected function getPOSTDataParams($command, $secured)
+    protected function getPOSTDataParams(array $command, bool $secured): array
     {
         $params = [];
         if (strlen($this->login) !== 0) {
@@ -91,7 +85,7 @@ class SocketConfig
         if (strlen($this->user) && isset($this->parameters["subuser"])) {
             $params[$this->parameters["subuser"]] = $this->user;
         }
-        if (!empty($command) && isset($this->parameters["command"])) {
+        if ($command !== [] && isset($this->parameters["command"])) {
             $newcommand = "";
             foreach ($command as $key => $val) {
                 if (is_null($val)) {
@@ -114,7 +108,7 @@ class SocketConfig
      * @param bool $secured if password has to be returned "hidden"
      * @return string POST data string
      */
-    public function getPOSTData($command = [], $secured = false)
+    public function getPOSTData(array $command = [], bool $secured = false): string
     {
         $params = $this->getPOSTDataParams($command, $secured);
         if ($this->getPersistent()) {
@@ -129,30 +123,27 @@ class SocketConfig
     /**
      * Add persistent parameter to request (request API session)
      *
-     * @param bool $value
      * @return $this
      */
-    public function setPersistent($value = false)
+    public function setPersistent(bool $value = false)
     {
-        $this->persistent = ($value !== false);
+        $this->persistent = $value;
         return $this;
     }
 
     /**
      * Get persistent parameter returned
      *
-     * @return bool
      */
-    public function getPersistent()
+    public function getPersistent(): bool
     {
         return $this->persistent;
     }
 
     /**
      * Get API Session ID in use
-     * @return string
      */
-    public function getSession()
+    public function getSession(): string
     {
         return $this->session;
     }
@@ -162,7 +153,7 @@ class SocketConfig
      * @param string $value account name
      * @return $this
      */
-    public function setLogin($value)
+    public function setLogin(string $value)
     {
         $this->session = "";
         $this->login = $value;
@@ -182,7 +173,7 @@ class SocketConfig
      * @param string $value account password
      * @return $this
      */
-    public function setPassword($value)
+    public function setPassword(string $value)
     {
         $this->session = "";
         $this->pw = $value;
@@ -194,7 +185,7 @@ class SocketConfig
      * @param string $value remote ip address
      * @return $this
      */
-    public function setRemoteAddress($value)
+    public function setRemoteAddress(string $value)
     {
         $this->remoteaddr = $value;
         return $this;
@@ -206,7 +197,7 @@ class SocketConfig
      * @param string $value API Session ID
      * @return $this
      */
-    public function setSession($value)
+    public function setSession(string $value)
     {
         $this->session = $value;
         // $this->login = "";
@@ -219,7 +210,7 @@ class SocketConfig
      * @param string $value subuser account name
      * @return $this
      */
-    public function setUser($value)
+    public function setUser(string $value)
     {
         $this->user = $value;
         return $this;

--- a/src/ClientFactory.php
+++ b/src/ClientFactory.php
@@ -1,6 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CNIC;
+
+use CNIC\CNR\Logger;
+use CNIC\CNR\SessionClient;
+use CNIC\IBS\Logger as IBSLogger;
+use CNIC\IBS\SessionClient as IBSSessionClient;
+use CNIC\MONIKER\SessionClient as MONIKERSessionClient;
 
 /**
  * ClientFactory
@@ -14,26 +22,25 @@ class ClientFactory
      * Returns Client Instance by configuration
      *
      * @param array<mixed> $params Configuration settings
-     * @param \CNIC\CNR\Logger|null $logger Logger Instance (optional)
-     * @return \CNIC\CNR\SessionClient|\CNIC\IBS\SessionClient
+     * @param Logger|null $logger Logger Instance (optional)
      * @throws \Exception
      */
-    public static function getClient($params, ?\CNIC\CNR\Logger $logger = null)
+    public static function getClient(array $params, ?Logger $logger = null): SessionClient|IBSSessionClient
     {
         // if we dynamically instantiate via string, phpStan starts complaining ...
         switch (strtoupper($params["registrar"])) {
             case "CNR":
             case "CNIC":
-                $cl = new \CNIC\CNR\SessionClient();
-                $cl->setCustomLogger($logger ?? new \CNIC\CNR\Logger());
+                $cl = new SessionClient();
+                $cl->setCustomLogger($logger ?? new Logger());
                 break;
             case "IBS":
-                $cl = new \CNIC\IBS\SessionClient();
-                $cl->setCustomLogger($logger ?? new \CNIC\IBS\Logger());
+                $cl = new IBSSessionClient();
+                $cl->setCustomLogger($logger ?? new IBSLogger());
                 break;
             case "MONIKER":
-                $cl = new \CNIC\MONIKER\SessionClient();
-                $cl->setCustomLogger($logger ?? new \CNIC\IBS\Logger());
+                $cl = new MONIKERSessionClient();
+                $cl->setCustomLogger($logger ?? new IBSLogger());
                 break;
             case "HEXONET":
             case "ISPAPI":

--- a/src/ColumnInterface.php
+++ b/src/ColumnInterface.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-#declare(strict_types=1);
 /**
  * CNIC
  * Copyright © CentralNic Group PLC
  */
+
 namespace CNIC;
 
 /**

--- a/src/CommandFormatter.php
+++ b/src/CommandFormatter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CNIC;
 
 /**
@@ -37,7 +39,7 @@ final class CommandFormatter
      * @param bool $toupper flag to convert keys to uppercase or leave as is
      * @return array<string,string>
      */
-    public static function flattenCommand($cmd, $toupper = true): array
+    public static function flattenCommand(array $cmd, bool $toupper = true): array
     {
         $newcmd = [];
         foreach ($cmd as $key => $val) {

--- a/src/CustomLoggerClass.php
+++ b/src/CustomLoggerClass.php
@@ -2,12 +2,15 @@
 
 declare(strict_types=1);
 
-#declare(strict_types=1);
 /**
  * MYCUSTOMNAMESPACE
  * Copyright © MYCUSTOMNAMESPACE
  */
+
 namespace MYCUSTOMNAMESPACE;
+
+use CNIC\CNR\Response;
+use CNIC\LoggerInterface;
 
 /**
  * MYCUSTOMNAMESPACE Logger
@@ -15,17 +18,17 @@ namespace MYCUSTOMNAMESPACE;
  * @psalm-api
  * @package MYCUSTOMNAMESPACE
  */
-class Logger implements \CNIC\LoggerInterface
+class Logger implements LoggerInterface
 {
     /**
      * Output/log given data
      *
      * @param string $post Post request data in string format
-     * @param \CNIC\CNR\Response $r Response to log
+     * @param Response $r Response to log
      * @param string|null $error Error message (optional)
      */
     #[\Override]
-    public function log(string $post, \CNIC\CNR\Response $r, ?string $error = null): void
+    public function log(string $post, Response $r, ?string $error = null): void
     {
         // apply your custom logging / output here
     }

--- a/src/IBS/Client.php
+++ b/src/IBS/Client.php
@@ -1,6 +1,6 @@
 <?php
 
-#declare(strict_types=1);
+declare(strict_types=1);
 
 /**
  * CNIC\IBS
@@ -9,24 +9,25 @@
 
 namespace CNIC\IBS;
 
+use CNIC\CNR\Client as CNRClient;
 use CNIC\CommandFormatter;
 use CNIC\IBS\Logger as L;
-use CNIC\IBS\SocketConfig;
 use CNIC\IBS\Response;
+use CNIC\IBS\SocketConfig;
 
 /**
  * IBS API Client
  *
  * @package CNIC\IBS
  */
-class Client extends \CNIC\CNR\Client
+class Client extends CNRClient
 {
     /**
      * Constructor
      *
      * @param string $path Path to the configuration file
      */
-    public function __construct($path = "")
+    public function __construct(string $path = "")
     {
         $contents = file_get_contents($path);
         if ($contents === false) {
@@ -50,10 +51,9 @@ class Client extends \CNIC\CNR\Client
      *
      * @param array<string,mixed> $cmd API command to encode
      * @param bool $secured secure password (when used for output)
-     * @return string
      */
     #[\Override]
-    public function getPOSTData($cmd, $secured = false)
+    public function getPOSTData(array $cmd, bool $secured = false): string
     {
         return $this->socketConfig->getPOSTData($cmd, $secured);
     }
@@ -65,7 +65,7 @@ class Client extends \CNIC\CNR\Client
      * @throws \Exception
      */
     #[\Override]
-    public function getSession()
+    public function getSession(): ?string
     {
         throw new \Exception("Feature `API Session` Not supported.");
     }
@@ -104,7 +104,7 @@ class Client extends \CNIC\CNR\Client
      * @return array<string>
      */
     #[\Override]
-    protected function autoIDNConvert($cmd)
+    protected function autoIDNConvert(array $cmd): array
     {
         // no IDN conversion needed
         return $cmd;
@@ -115,10 +115,9 @@ class Client extends \CNIC\CNR\Client
      *
      * @param array<mixed> $cmd API command to request
      * @param string $path Path to the API endpoint
-     * @return Response
      */
     #[\Override]
-    public function request(array $cmd = [], $path = "")
+    public function request(array $cmd = [], $path = ""): Response
     {
         // flatten nested api command bulk parameters and sort them
         $mycmd = CommandFormatter::flattenCommand($cmd + ["ResponseFormat" => "JSON"], false);
@@ -130,7 +129,7 @@ class Client extends \CNIC\CNR\Client
         ];
         $data = $this->getPOSTData($mycmd);
 
-        if (!$this->chandle) {
+        if (!$this->chandle instanceof \CurlHandle) {
             $tmp = curl_init();
             if ($tmp === false) {
                 $r = new Response("nocurl", $mycmd, $cfg, $this->context);
@@ -164,9 +163,8 @@ class Client extends \CNIC\CNR\Client
             CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4 // IBS / Moniker only
         ] + $this->curlopts);
 
-        // which is by default tested for by phpStan
-        /** @var string|false $r */
         $r = curl_exec($this->chandle);
+        \assert(\is_string($r) || $r === false);
         $error = null;
         if ($r === false) {
             $error = curl_error($this->chandle);

--- a/src/IBS/Column.php
+++ b/src/IBS/Column.php
@@ -2,12 +2,14 @@
 
 declare(strict_types=1);
 
-#declare(strict_types=1);
 /**
  * CNIC\IBS
  * Copyright © CentralNic Group PLC
  */
+
 namespace CNIC\IBS;
+
+use CNIC\CNR\Column as CNRColumn;
 
 /**
  * IBS Column
@@ -15,6 +17,6 @@ namespace CNIC\IBS;
  * @psalm-api
  * @package CNIC\IBS
  */
-class Column extends \CNIC\CNR\Column // implements \CNIC\ColumnInterface
+class Column extends CNRColumn // implements \CNIC\ColumnInterface
 {
 }

--- a/src/IBS/Logger.php
+++ b/src/IBS/Logger.php
@@ -1,6 +1,6 @@
 <?php
 
-#declare(strict_types=1);
+declare(strict_types=1);
 
 /**
  * CNIC\IBS
@@ -9,25 +9,29 @@
 
 namespace CNIC\IBS;
 
+use CNIC\CNR\Response;
+use CNIC\IBS\Response as IBSResponse;
+use CNIC\LoggerInterface;
+
 /**
  * IBS Logger
  *
  * @package CNIC\IBS
  */
-final class Logger implements \CNIC\LoggerInterface
+final class Logger implements LoggerInterface
 {
     /**
      * Output/log given data
      *
      * @param string $post Post request data in string format
-     * @param \CNIC\CNR\Response $r Response to log
+     * @param Response $r Response to log
      * @param string|null $error Error message (optional)
      */
     #[\Override]
-    public function log(string $post, \CNIC\CNR\Response $r, ?string $error = null): void
+    public function log(string $post, Response $r, ?string $error = null): void
     {
         $requestUrl = '';
-        if ($r instanceof \CNIC\IBS\Response) {
+        if ($r instanceof IBSResponse) {
             $requestUrl = $r->getRequestURL();
         }
 
@@ -36,7 +40,7 @@ final class Logger implements \CNIC\LoggerInterface
             "\tAPI:  " . $requestUrl . "\n" .
             "\tPOST: " . $post . "\n\n" .
             "R E S P O N S E\n" .
-            (($error !== null && $error !== '') ? "\tHTTP communication failed: " . $error . "\n" : "") .
+            ($error !== null && $error !== '' ? "\tHTTP communication failed: " . $error . "\n" : "") .
             "\t" . (preg_replace("/\n/", "\n\t", $r->getPlain()) ?? $r->getPlain())
         );
     }

--- a/src/IBS/Record.php
+++ b/src/IBS/Record.php
@@ -2,12 +2,14 @@
 
 declare(strict_types=1);
 
-#declare(strict_types=1);
 /**
  * CNIC\IBS
  * Copyright © CentralNic Group PLC
  */
+
 namespace CNIC\IBS;
+
+use CNIC\CNR\Record as CNRRecord;
 
 /**
  * IBS Record
@@ -15,6 +17,6 @@ namespace CNIC\IBS;
  * @psalm-api
  * @package CNIC\IBS
  */
-class Record extends \CNIC\CNR\Record // implements \CNIC\RecordInterface
+class Record extends CNRRecord // implements \CNIC\RecordInterface
 {
 }

--- a/src/IBS/Response.php
+++ b/src/IBS/Response.php
@@ -1,6 +1,6 @@
 <?php
 
-#declare(strict_types=1);
+declare(strict_types=1);
 
 /**
  * CNIC\IBS
@@ -9,11 +9,12 @@
 
 namespace CNIC\IBS;
 
-use CNIC\IBS\ResponseParser as RP;
-use CNIC\IBS\ResponseTranslator as RT;
-use CNIC\CommandFormatter;
 use CNIC\CNR\Column;
 use CNIC\CNR\Record;
+use CNIC\CNR\Response as CNRResponse;
+use CNIC\CommandFormatter;
+use CNIC\IBS\ResponseParser as RP;
+use CNIC\IBS\ResponseTranslator as RT;
 
 /**
  * IBS Response
@@ -21,19 +22,19 @@ use CNIC\CNR\Record;
  * @psalm-api
  * @package CNIC\IBS
  */
-class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
+class Response extends CNRResponse // implements \CNIC\ResponseInterface
 {
     /**
      * Regex for pagination related column keys
      * @var non-empty-string
      */
-    protected $paginationkeys = "/^(.+)?count|total(_.+)?$/"; // to be extended
+    protected string $paginationkeys = "/^(.+)?count|total(_.+)?$/"; // to be extended
 
     /**
      * Context data for the response
      * @var array<string,mixed>
      */
-    protected $context;
+    protected array $context;
 
     /**
      * Constructor
@@ -42,7 +43,7 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
      * @param array<string> $ph placeholder array to get vars in response description dynamically replaced
      * @param array<string,mixed> $context context data for the response (for use in custom loggers etc., optional, has no impact on SDK behaviour)
      */
-    public function __construct($raw, $cmd = [], $ph = [], $context = [])
+    public function __construct(string $raw, array $cmd = [], array $ph = [], array $context = [])
     {
         if (isset($cmd["password"])) { // make password no longer accessible
             $cmd["password"] = "***";
@@ -74,7 +75,7 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
             $d = [];
             foreach ($colKeys as $k) {
                 $col = $this->getColumn($k);
-                if ($col) {
+                if ($col instanceof Column) {
                     $v = $col->getDataByIndex($i);
                     if ($v !== null) {
                         $d[$k] = $v;
@@ -87,10 +88,9 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
 
     /**
      * Get API response code
-     * @return int
      */
     #[\Override]
-    public function getCode()
+    public function getCode(): int
     {
         foreach (["code", "product_0_code"] as $key) {
             if (isset($this->hash[$key])) {
@@ -102,29 +102,26 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
 
     /**
      * Get API response code
-     * @return string
      */
-    public function getStatus()
+    public function getStatus(): string
     {
         return $this->hash["status"];
     }
 
     /**
      * Get API response description
-     * @return string
      */
     #[\Override]
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->hash["message"] ?? $this->hash["product_0_message"] ?? "Command completed successfully";
     }
 
     /**
      * Get Plain API response
-     * @return string
      */
     #[\Override]
-    public function getPlain()
+    public function getPlain(): string
     {
         return $this->raw;
     }
@@ -134,7 +131,7 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
      * @throws \Exception
      */
     #[\Override]
-    public function getQueuetime()
+    public function getQueuetime(): float
     {
         throw new \Exception("Not supported");
     }
@@ -144,7 +141,7 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
      * @return array<string,mixed>
      */
     #[\Override]
-    public function getHash()
+    public function getHash(): array
     {
         return $this->hash;
     }
@@ -154,7 +151,7 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
      * @throws \Exception
      */
     #[\Override]
-    public function getRuntime()
+    public function getRuntime(): float
     {
         throw new \Exception("Not supported");
     }
@@ -162,10 +159,9 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
     /**
      * Check if current API response represents an error case
      * API response code is an 5xx code
-     * @return bool
      */
     #[\Override]
-    public function isError()
+    public function isError(): bool
     {
         return ($this->hash["status"] === "FAILURE");
     }
@@ -173,10 +169,9 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
     /**
      * Check if current API response represents a success case
      * API response code is an 2xx code
-     * @return bool
      */
     #[\Override]
-    public function isSuccess()
+    public function isSuccess(): bool
     {
         return $this->hash["status"] === "SUCCESS";
     }
@@ -186,7 +181,7 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
      * @throws \Exception
      */
     #[\Override]
-    public function isTmpError()
+    public function isTmpError(): bool
     {
         throw new \Exception("Not supported");
     }
@@ -196,7 +191,7 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
      * @throws \Exception
      */
     #[\Override]
-    public function isPending()
+    public function isPending(): bool
     {
         throw new \Exception("Not supported");
     }
@@ -208,7 +203,7 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
      * @return $this
      */
     #[\Override]
-    public function addColumn($key, $data)
+    public function addColumn(string $key, array $data)
     {
         $col = new Column($key, $data);
         $this->columns[] = $col;
@@ -218,11 +213,11 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
 
     /**
      * Add a record to the record list
-     * @param array<string> $h row hash data
+     * @param array<string,mixed> $h row hash data
      * @return $this
      */
     #[\Override]
-    public function addRecord($h)
+    public function addRecord(array $h)
     {
         $this->records[] = new Record($h);
         return $this;
@@ -231,10 +226,9 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
     /**
      * Get column by column name
      * @param string $key column name
-     * @return Column|null
      */
     #[\Override]
-    public function getColumn($key)
+    public function getColumn(string $key): ?Column
     {
         return ($this->hasColumn($key) ? $this->columns[array_search($key, $this->columnkeys)] : null);
     }
@@ -243,13 +237,12 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
      * Get Data by Column Name and Index
      * @param string $colkey column name
      * @param int $index column data index
-     * @return string|null
      */
     #[\Override]
-    public function getColumnIndex($colkey, $index)
+    public function getColumnIndex(string $colkey, int $index): mixed
     {
         $col = $this->getColumn($colkey);
-        return $col ? $col->getDataByIndex($index) : null;
+        return $col instanceof Column ? $col->getDataByIndex($index) : null;
     }
 
     /**
@@ -258,7 +251,7 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
      * @return string[]
      */
     #[\Override]
-    public function getColumnKeys($filterPaginationKeys = false)
+    public function getColumnKeys(bool $filterPaginationKeys = false): array
     {
         if ($filterPaginationKeys) {
             // Ensure that preg_grep always returns an array
@@ -273,7 +266,7 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
      * @return Column[]
      */
     #[\Override]
-    public function getColumns()
+    public function getColumns(): array
     {
         return $this->columns;
     }
@@ -283,57 +276,52 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
      * @return array<string>
      */
     #[\Override]
-    public function getCommand()
+    public function getCommand(): array
     {
         return CommandFormatter::getSortedCommand($this->command);
     }
 
     /**
      * Get Command used in this request in plain text format
-     * @return string
      */
     #[\Override]
-    public function getCommandPlain()
+    public function getCommandPlain(): string
     {
         return CommandFormatter::formatCommand($this->getCommand());
     }
 
     /**
      * Get Page Number of current List Query
-     * @return int|null
      */
     #[\Override]
-    public function getCurrentPageNumber()
+    public function getCurrentPageNumber(): ?int
     {
         return 1;
     }
 
     /**
      * Get Record of current record index
-     * @return Record|null
      */
     #[\Override]
-    public function getCurrentRecord()
+    public function getCurrentRecord(): ?Record
     {
         return $this->hasCurrentRecord() ? $this->records[$this->recordIndex] : null;
     }
 
     /**
      * Get Index of first row in this response
-     * @return int|null
      */
     #[\Override]
-    public function getFirstRecordIndex()
+    public function getFirstRecordIndex(): ?int
     {
         return 0;
     }
 
     /**
      * Get last record index of the current list query
-     * @return int|null
      */
     #[\Override]
-    public function getLastRecordIndex()
+    public function getLastRecordIndex(): ?int
     {
         static $last = null;
 
@@ -354,17 +342,16 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
      * @throws \Exception
      */
     #[\Override]
-    public function getListHash()
+    public function getListHash(): array
     {
         throw new \Exception("Not implemented.");
     }
 
     /**
      * Get next record in record list
-     * @return Record|null
      */
     #[\Override]
-    public function getNextRecord()
+    public function getNextRecord(): ?Record
     {
         if ($this->hasNextRecord()) {
             return $this->records[++$this->recordIndex];
@@ -374,10 +361,9 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
 
     /**
      * Get Page Number of next list query
-     * @return int|null
      */
     #[\Override]
-    public function getNextPageNumber()
+    public function getNextPageNumber(): ?int
     {
         $cp = $this->getCurrentPageNumber();
         if ($cp === null) {
@@ -390,10 +376,9 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
 
     /**
      * Get the number of pages available for this list query
-     * @return int
      */
     #[\Override]
-    public function getNumberOfPages()
+    public function getNumberOfPages(): int
     {
         $t = $this->getRecordsTotalCount();
         $limit = $this->getRecordsLimitation();
@@ -408,7 +393,7 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
      * @return array<string,int|null>
      */
     #[\Override]
-    public function getPagination()
+    public function getPagination(): array
     {
         return [
             "COUNT" => $this->getRecordsCount(),
@@ -425,10 +410,9 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
 
     /**
      * Get Page Number of previous list query
-     * @return int|null
      */
     #[\Override]
-    public function getPreviousPageNumber()
+    public function getPreviousPageNumber(): ?int
     {
         $cp = $this->getCurrentPageNumber();
         if ($cp === null) {
@@ -443,10 +427,9 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
 
     /**
      * Get previous record in record list
-     * @return Record|null
      */
     #[\Override]
-    public function getPreviousRecord()
+    public function getPreviousRecord(): ?Record
     {
         if ($this->hasPreviousRecord()) {
             return $this->records[--$this->recordIndex];
@@ -457,10 +440,9 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
     /**
      * Get Record at given index
      * @param int $idx record index
-     * @return Record|null
      */
     #[\Override]
-    public function getRecord($idx)
+    public function getRecord(int $idx): ?Record
     {
         if ($idx >= 0 && $this->getRecordsCount() > $idx) {
             return $this->records[$idx];
@@ -473,27 +455,25 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
      * @return Record[]
      */
     #[\Override]
-    public function getRecords()
+    public function getRecords(): array
     {
         return $this->records;
     }
 
     /**
      * Get count of rows in this response
-     * @return int
      */
     #[\Override]
-    public function getRecordsCount()
+    public function getRecordsCount(): int
     {
         return count($this->records);
     }
 
     /**
      * Get total count of records available for the list query
-     * @return int
      */
     #[\Override]
-    public function getRecordsTotalCount()
+    public function getRecordsTotalCount(): int
     {
         return $this->getRecordsCount();
     }
@@ -501,30 +481,27 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
     /**
      * Get limit(ation) setting of the current list query
      * This is the count of requested rows
-     * @return int
      */
     #[\Override]
-    public function getRecordsLimitation()
+    public function getRecordsLimitation(): int
     {
         return $this->getRecordsCount();
     }
 
     /**
      * Check if this list query has a next page
-     * @return bool
      */
     #[\Override]
-    public function hasNextPage()
+    public function hasNextPage(): bool
     {
         return false;
     }
 
     /**
      * Check if this list query has a previous page
-     * @return bool
      */
     #[\Override]
-    public function hasPreviousPage()
+    public function hasPreviousPage(): bool
     {
         return false;
     }
@@ -543,19 +520,17 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
     /**
      * Check if column exists in response
      * @param string $key column name
-     * @return bool
      */
-    private function hasColumn($key)
+    private function hasColumn(string $key): bool
     {
-        return (in_array($key, $this->columnkeys));
+        return in_array($key, $this->columnkeys);
     }
 
     /**
      * Check if the record list contains a record for the
      * current record index in use
-     * @return bool
      */
-    private function hasCurrentRecord()
+    private function hasCurrentRecord(): bool
     {
         $len = $this->getRecordsCount();
         return (
@@ -568,9 +543,8 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
     /**
      * Check if the record list contains a next record for the
      * current record index in use
-     * @return bool
      */
-    private function hasNextRecord()
+    private function hasNextRecord(): bool
     {
         $next = $this->recordIndex + 1;
         return ($this->hasCurrentRecord() && ($next < $this->getRecordsCount()));
@@ -579,9 +553,8 @@ class Response extends \CNIC\CNR\Response // implements \CNIC\ResponseInterface
     /**
      * Check if the record list contains a previous record for the
      * current record index in use
-     * @return bool
      */
-    private function hasPreviousRecord()
+    private function hasPreviousRecord(): bool
     {
         return ($this->recordIndex > 0 && $this->hasCurrentRecord());
     }

--- a/src/IBS/ResponseParser.php
+++ b/src/IBS/ResponseParser.php
@@ -1,6 +1,6 @@
 <?php
 
-#declare(strict_types=1);
+declare(strict_types=1);
 
 /**
  * CNIC\IBS
@@ -23,9 +23,9 @@ final class ResponseParser
      * @param array<string> $cmd API command used within this request
      * @return array<string,mixed>
      */
-    public static function parse($raw, $cmd = [])
+    public static function parse(string $raw, array $cmd = []): array
     {
-        $isJson = empty($cmd) || (isset($cmd["ResponseFormat"]) && strtoupper($cmd["ResponseFormat"]) === "JSON");
+        $isJson = $cmd === [] || (isset($cmd["ResponseFormat"]) && strtoupper($cmd["ResponseFormat"]) === "JSON");
 
         $result = $isJson ? json_decode($raw, true) : null;
 
@@ -49,7 +49,7 @@ final class ResponseParser
         }
 
         // Normalize date separators (handles nested arrays)
-        array_walk_recursive($result, function (mixed &$value, string $key) {
+        array_walk_recursive($result, function (mixed &$value, string $key): void {
             if (is_string($value) && preg_match("/date|paiduntil|expiration$/i", $key)) {
                 $value = str_replace("/", "-", $value);
             }

--- a/src/IBS/ResponseTemplateManager.php
+++ b/src/IBS/ResponseTemplateManager.php
@@ -1,6 +1,6 @@
 <?php
 
-#declare(strict_types=1);
+declare(strict_types=1);
 
 /**
  * CNIC\IBS
@@ -24,7 +24,7 @@ final class ResponseTemplateManager
      * template container
      * @var array<string>
      */
-    public static $templates = [
+    public static array $templates = [
         "403" => "status=FAILURE\r\nmessage=403 Forbidden\r\n",
         "404" => "status=FAILURE\r\nmessage=421 Page not found\r\n",
         "500" => "status=FAILURE\r\nmessage=500 Internal server error\r\n",
@@ -41,9 +41,8 @@ final class ResponseTemplateManager
      * Generate API response template string for given status and description
      * @param string $status API response code
      * @param string $description API response description
-     * @return string
      */
-    public static function generateTemplate($status, $description)
+    public static function generateTemplate(string $status, string $description): string
     {
         return "status=$status\r\nmessage=$description\r\n";
     }
@@ -53,9 +52,8 @@ final class ResponseTemplateManager
      * @param string $id template id
      * @param string $plain API plain response or API response code (when providing $descr)
      * @param string|null $descr API response description
-     * @return self
      */
-    public static function addTemplate($id, $plain, $descr = null)
+    public static function addTemplate(string $id, string $plain, ?string $descr = null): self
     {
         self::$templates[$id] = is_null($descr) ? $plain : self::generateTemplate($plain, $descr);
         return new self();
@@ -64,9 +62,8 @@ final class ResponseTemplateManager
     /**
      * Get response template instance from template container
      * @param string $id template id
-     * @return Response
      */
-    public static function getTemplate($id)
+    public static function getTemplate(string $id): Response
     {
         if (self::hasTemplate($id)) {
             return new Response($id);
@@ -78,7 +75,7 @@ final class ResponseTemplateManager
      * Return all available response templates
      * @return array<mixed>
      */
-    public static function getTemplates()
+    public static function getTemplates(): array
     {
         $tpls = [];
         foreach (self::$templates as $key => $raw) {
@@ -90,9 +87,8 @@ final class ResponseTemplateManager
     /**
      * Check if given template exists in template container
      * @param string $id template id
-     * @return bool
      */
-    public static function hasTemplate($id)
+    public static function hasTemplate(string $id): bool
     {
         return array_key_exists($id, self::$templates);
     }
@@ -101,9 +97,8 @@ final class ResponseTemplateManager
      * Check if given API response hash matches a given template by code and description
      * @param array<string> $tpl api response hash
      * @param string $id template id
-     * @return bool
      */
-    public static function isTemplateMatchHash($tpl, $id)
+    public static function isTemplateMatchHash(array $tpl, string $id): bool
     {
         $h = self::getTemplate($id)->getHash();
         return (
@@ -116,9 +111,8 @@ final class ResponseTemplateManager
      * Check if given API plain response matches a given template by code and description
      * @param string $plain API plain response
      * @param string $id template id
-     * @return bool
      */
-    public static function isTemplateMatchPlain($plain, $id)
+    public static function isTemplateMatchPlain(string $plain, string $id): bool
     {
         $h = self::getTemplate($id)->getHash();
         $tpl = RP::parse($plain);

--- a/src/IBS/ResponseTranslator.php
+++ b/src/IBS/ResponseTranslator.php
@@ -1,6 +1,6 @@
 <?php
 
-#declare(strict_types=1);
+declare(strict_types=1);
 
 /**
  * CNIC\IBS
@@ -22,26 +22,25 @@ final class ResponseTranslator
      * hidden class var of API description regex mappings for translation
      * @var array<mixed>
      */
-    private static $descriptionRegexMap = [];
+    private static array $descriptionRegexMap = [];
 
     /**
      * translate a raw api response
      * @param string $raw API raw response
      * @param array<string> $cmd requested API command
      * @param array<string> $ph list of place holder vars
-     * @return string
      * @psalm-suppress UnusedParam $cmd kept for API consistency with CNR\ResponseTranslator
      */
-    public static function translate($raw, $cmd, $ph = [])
+    public static function translate(string $raw, array $cmd, array $ph = []): string
     {
-        $newraw = empty($raw) ? "empty" : $raw;
+        $newraw = $raw === '' || $raw === '0' ? "empty" : $raw;
         // Hint: Empty API Response (replace {CONNECTION_URL} later)
 
         // curl error handling
         $httperror = "";
         $isHTTPError = substr($newraw, 0, 10) === "httperror|";
         if ($isHTTPError) {
-            list($newraw, $httperror) = explode("|", $newraw);
+            [$newraw, $httperror] = explode("|", $newraw);
         }
 
         // Explicit call for a static template
@@ -114,7 +113,7 @@ final class ResponseTranslator
      * @param string $val The value to be used in replacement if a match is found.
      * @return bool Returns true if replacements were performed, false otherwise.
      */
-    private static function findMatch($regex, &$newraw, $val)
+    private static function findMatch(string $regex, string &$newraw, string $val): bool
     {
         // match the response for given description
         // NOTE: we match if the description starts with the given description
@@ -138,9 +137,8 @@ final class ResponseTranslator
      * Replace placeholder vars like {CONNECTION_URL} in a string
      * @param string $raw input string
      * @param array<string> $ph placeholder key-value pairs
-     * @return string
      */
-    protected static function replacePlaceholders($raw, $ph)
+    protected static function replacePlaceholders(string $raw, array $ph): string
     {
         if (preg_match("/\{[A-Z][A-Z0-9_]*\}/", $raw)) {
             foreach ($ph as $key => $val) {

--- a/src/IBS/SessionClient.php
+++ b/src/IBS/SessionClient.php
@@ -1,6 +1,6 @@
 <?php
 
-#declare(strict_types=1);
+declare(strict_types=1);
 
 /**
  * CNIC\IBS
@@ -9,13 +9,15 @@
 
 namespace CNIC\IBS;
 
+use CNIC\IBS\Client;
+
 /**
  * IBS API Client
  *
  * @psalm-api
  * @package CNIC\IBS
  */
-class SessionClient extends \CNIC\IBS\Client
+class SessionClient extends Client
 {
     /**
      * Constructor
@@ -35,9 +37,8 @@ class SessionClient extends \CNIC\IBS\Client
     /**
      * Perform API login to start session-based communication
      * @throws \Exception
-     * @return Response
      */
-    public function login()
+    public function login(): Response
     {
         throw new \Exception("Method not supported");
     }
@@ -45,9 +46,8 @@ class SessionClient extends \CNIC\IBS\Client
     /**
      * Perform API logout to close API session in use
      * @throws \Exception
-     * @return Response
      */
-    public function logout()
+    public function logout(): Response
     {
         throw new \Exception("Method not supported");
     }
@@ -59,7 +59,7 @@ class SessionClient extends \CNIC\IBS\Client
      * @return $this
      * @psalm-suppress PossiblyUnusedParam stub for future implementation
      */
-    public function saveSession(&$session)
+    public function saveSession(array &$session)
     {
         throw new \Exception("Method not supported");
     }
@@ -72,7 +72,7 @@ class SessionClient extends \CNIC\IBS\Client
      * @return $this
      * @psalm-suppress PossiblyUnusedParam stub for future implementation
      */
-    public function reuseSession(&$session)
+    public function reuseSession(array &$session)
     {
         throw new \Exception("Method not supported");
     }

--- a/src/IBS/SocketConfig.php
+++ b/src/IBS/SocketConfig.php
@@ -1,6 +1,6 @@
 <?php
 
-#declare(strict_types=1);
+declare(strict_types=1);
 
 /**
  * CNIC\IBS
@@ -9,36 +9,35 @@
 
 namespace CNIC\IBS;
 
+use CNIC\CNR\SocketConfig as CNRSocketConfig;
+
 /**
  * IBS SocketConfig
  *
  * @package CNIC\IBS
  */
-final class SocketConfig extends \CNIC\CNR\SocketConfig
+final class SocketConfig extends CNRSocketConfig
 {
     /**
      * account name
-     * @var string
      */
-    protected $login = "";
+    protected string $login = "";
 
     /**
      * account password
-     * @var string
      */
-    protected $pw = "";
+    protected string $pw = "";
 
     /**
      * remote ip address (ip filter)
-     * @var string
      */
-    protected $remoteaddr = "";
+    protected string $remoteaddr = "";
 
     /**
      * list of http request parameters
      * @var array<string>
      */
-    protected $parameters;
+    protected array $parameters;
 
     /**
      * Constructor
@@ -57,7 +56,7 @@ final class SocketConfig extends \CNIC\CNR\SocketConfig
      * @return array<string,string>
      */
     #[\Override]
-    protected function getPOSTDataParams($command, $secured)
+    protected function getPOSTDataParams(array $command, bool $secured): array
     {
         $params = $command; // here $command is just an array of request parameters
         if (strlen($this->login) !== 0) {
@@ -76,10 +75,9 @@ final class SocketConfig extends \CNIC\CNR\SocketConfig
      * Create POST data string out of connection data
      * @param array<int|string,mixed> $command API Command to request
      * @param bool $secured if password has to be returned "hidden"
-     * @return string
      */
     #[\Override]
-    public function getPOSTData($command = [], $secured = false)
+    public function getPOSTData(array $command = [], bool $secured = false): string
     {
         $params = $this->getPOSTDataParams($command, $secured);
         return http_build_query($params);//RFC1738 x-www-form-urlencoded as default

--- a/src/LoggerInterface.php
+++ b/src/LoggerInterface.php
@@ -2,12 +2,14 @@
 
 declare(strict_types=1);
 
-#declare(strict_types=1);
 /**
  * CNIC
  * Copyright © CentralNic Group PLC
  */
+
 namespace CNIC;
+
+use CNIC\CNR\Response;
 
 /**
  * Common Logger Interface
@@ -21,8 +23,8 @@ interface LoggerInterface
      * Output/log given data
      *
      * @param string $post Post request data in string format
-     * @param \CNIC\CNR\Response $r Response to log
+     * @param Response $r Response to log
      * @param string|null $error Error message (optional)
      */
-    public function log(string $post, \CNIC\CNR\Response $r, ?string $error = null): void;
+    public function log(string $post, Response $r, ?string $error = null): void;
 }

--- a/src/MONIKER/SessionClient.php
+++ b/src/MONIKER/SessionClient.php
@@ -2,12 +2,14 @@
 
 declare(strict_types=1);
 
-#declare(strict_types=1);
 /**
  * CNIC\MONIKER
  * Copyright © CentralNic Group PLC
  */
+
 namespace CNIC\MONIKER;
+
+use CNIC\IBS\SessionClient as IBSSessionClient;
 
 /**
  * MONIKER API Client
@@ -15,6 +17,6 @@ namespace CNIC\MONIKER;
  * @package CNIC\MONIKER
  */
 
-final class SessionClient extends \CNIC\IBS\SessionClient
+final class SessionClient extends IBSSessionClient
 {
 }

--- a/src/RecordInterface.php
+++ b/src/RecordInterface.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-#declare(strict_types=1);
 /**
  * CNIC
  * Copyright © CentralNic Group PLC
  */
+
 namespace CNIC;
 
 /**

--- a/src/ResponseInterface.php
+++ b/src/ResponseInterface.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-#declare(strict_types=1);
 /**
  * CNIC
  * Copyright © CentralNic Group PLC
  */
+
 namespace CNIC;
 
 /**
@@ -118,9 +118,9 @@ interface ResponseInterface
      * Get Data by Column Name and Index
      * @param string $colkey column name
      * @param int $index column data index
-     * @return string|null column data at index or null if not found
+     * @return mixed|null column data at index or null if not found
      */
-    public function getColumnIndex(string $colkey, int $index): ?string;
+    public function getColumnIndex(string $colkey, int $index): mixed;
 
     /**
      * Get Column Names
@@ -132,7 +132,7 @@ interface ResponseInterface
      * Get List of Columns
      * @return ColumnInterface[] Array of Columns
      */
-    public function getColumns();
+    public function getColumns(): array;
 
     /**
      * Get Command used in this request
@@ -223,7 +223,7 @@ interface ResponseInterface
      * Get all Records
      * @return RecordInterface[] array of records
      */
-    public function getRecords();
+    public function getRecords(): array;
 
     /**
      * Get count of rows in this response

--- a/tests/CNR/ClientTest.php
+++ b/tests/CNR/ClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 //declare(strict_types=1);
 
 namespace CNICTEST\CNR;
@@ -7,42 +9,40 @@ namespace CNICTEST\CNR;
 use CNIC\ClientFactory as CF;
 use CNIC\CNR\Client as CL;
 use CNIC\CNR\Response as R;
+use CNIC\CNR\SessionClient;
 use CNIC\IDNA\Factory\ConverterFactory;
+use PHPUnit\Framework\TestCase;
 
-final class ClientTest extends \PHPUnit\Framework\TestCase
+final class ClientTest extends TestCase
 {
-    /**
-     * @var \CNIC\CNR\SessionClient $cl
-     */
-    public static $cl;
+    public static SessionClient $cl;
     /**
      * @var string user name (with role as we don't know the account pw)
      */
-    public static $user;
+    public static string $user;
     /**
      * @var string user name excluding role
      */
-    public static $userNoRole;
+    public static string $userNoRole;
     /**
      * @var string password
      */
-    public static $pw;
+    public static string $pw;
     /**
      * @var string role id
      */
-    public static $role;
+    public static string $role;
     /**
      * @var string role password
      */
-    public static $rolepw;
+    public static string $rolepw;
 
     public static function setUpBeforeClass(): void
     {
-        //session_start();
-        /** @var \CNIC\CNR\SessionClient $cl */
         $cl = CF::getClient([
             "registrar" => "CNR"
         ]);
+        \assert($cl instanceof SessionClient);
         self::$cl = $cl;
         self::$user = getenv("RTLDEV_MW_CI_USER_CNR") ?: "";
         if (self::$user === "") {
@@ -218,12 +218,13 @@ final class ClientTest extends \PHPUnit\Framework\TestCase
 
     public function testSaveReuseSession(): void
     {
+        $session = [];
         self::$cl->setSession("12345678")
-            ->saveSession($_SESSION);
+            ->saveSession($session);
         $cl2 = CF::getClient([
             "registrar" => "CNR"
         ]);
-        $cl2->reuseSession($_SESSION);
+        $cl2->reuseSession($session);
         $tmp = $cl2->getPOSTData([
             "COMMAND" => "StatusAccount"
         ]);
@@ -435,7 +436,7 @@ final class ClientTest extends \PHPUnit\Framework\TestCase
         foreach ($idns as $idn => $ace) {
             $tmp = idn_to_ascii(
                 $idn,
-                ((bool)preg_match("/\.(art|be|ca|de|fr|pm|re|swiss|tf|wf|yt)\.?$/i", $idn)) ?
+                (bool)preg_match("/\.(art|be|ca|de|fr|pm|re|swiss|tf|wf|yt)\.?$/i", $idn) ?
                     IDNA_NONTRANSITIONAL_TO_ASCII :
                     IDNA_DEFAULT,
                 INTL_IDNA_VARIANT_UTS46

--- a/tests/CNR/ColumnTest.php
+++ b/tests/CNR/ColumnTest.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 //declare(strict_types=1);
 namespace CNICTEST\CNR;
 
-final class ColumnTest extends \PHPUnit\Framework\TestCase
+use CNIC\CNR\Column;
+use PHPUnit\Framework\TestCase;
+
+final class ColumnTest extends TestCase
 {
     public function testGetKey(): void
     {
-        $col = new \CNIC\CNR\Column("DOMAIN", ["mydomain1.com", "mydomain2.com", "mydomain3.com"]);
+        $col = new Column("DOMAIN", ["mydomain1.com", "mydomain2.com", "mydomain3.com"]);
         $this->assertEquals("DOMAIN", $col->getKey());
     }
 }

--- a/tests/CNR/RecordTest.php
+++ b/tests/CNR/RecordTest.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 //declare(strict_types=1);
 namespace CNICTEST\CNR;
 
-final class RecordTest extends \PHPUnit\Framework\TestCase
+use CNIC\CNR\Record;
+use PHPUnit\Framework\TestCase;
+
+final class RecordTest extends TestCase
 {
     public function testGetData(): void
     {
@@ -15,13 +18,13 @@ final class RecordTest extends \PHPUnit\Framework\TestCase
             "RNDINT" => "321",
             "SUM"    => "1"
         ];
-        $rec = new \CNIC\CNR\Record($d);
+        $rec = new Record($d);
         $this->assertEquals($d, $rec->getData());
     }
 
     public function testGetDataByKey(): void
     {
-        $rec = new \CNIC\CNR\Record([
+        $rec = new Record([
             "DOMAIN" => "mydomain.com",
             "RATING" => "1",
             "RNDINT" => "321",

--- a/tests/CNR/ResponseTemplateManagerTest.php
+++ b/tests/CNR/ResponseTemplateManagerTest.php
@@ -1,13 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 //declare(strict_types=1);
 
 namespace CNICTEST\CNR;
 
 use CNIC\CNR\Response as R;
 use CNIC\CNR\ResponseTemplateManager as RTM;
+use PHPUnit\Framework\TestCase;
 
-final class ResponseTemplateManagerTest extends \PHPUnit\Framework\TestCase
+final class ResponseTemplateManagerTest extends TestCase
 {
     public function testGetTemplateNotFound(): void
     {

--- a/tests/CNR/ResponseTest.php
+++ b/tests/CNR/ResponseTest.php
@@ -1,22 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 //declare(strict_types=1);
 
 namespace CNICTEST\CNR;
 
 use CNIC\CNR\Response as R;
 use CNIC\CNR\ResponseTemplateManager as RTM;
+use PHPUnit\Framework\TestCase;
 
-final class ResponseTest extends \PHPUnit\Framework\TestCase
+final class ResponseTest extends TestCase
 {
     /**
      * @var string user name
      */
-    public static $user;
+    public static string $user;
     /**
      * @var string password
      */
-    public static $pw;
+    public static string $pw;
 
     public static function setupBeforeClass(): void
     {

--- a/tests/CNR/ResponseTranslatorTest.php
+++ b/tests/CNR/ResponseTranslatorTest.php
@@ -1,14 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 //declare(strict_types=1);
 
 namespace CNICTEST\CNR;
 
 use CNIC\CNR\Response as R;
-use CNIC\CNR\ResponseTranslator as RT;
 use CNIC\CNR\ResponseTemplateManager as RTM;
+use CNIC\CNR\ResponseTranslator as RT;
+use PHPUnit\Framework\TestCase;
 
-final class ResponseTranslatorTest extends \PHPUnit\Framework\TestCase
+final class ResponseTranslatorTest extends TestCase
 {
     /**
      * Test place holder vars replacement mechanism

--- a/tests/CNR/SocketConfigTest.php
+++ b/tests/CNR/SocketConfigTest.php
@@ -6,8 +6,9 @@ declare(strict_types=1);
 namespace CNICTEST\CNR;
 
 use CNIC\CNR\SocketConfig as SC;
+use PHPUnit\Framework\TestCase;
 
-final class SocketConfigTest extends \PHPUnit\Framework\TestCase
+final class SocketConfigTest extends TestCase
 {
     /**
      * test getPOSTData method

--- a/tests/CNR/app.php
+++ b/tests/CNR/app.php
@@ -1,5 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
+use CNIC\ClientFactory;
+
 require __DIR__ . '/../../vendor/autoload.php';
 
 $user = getenv('RTLDEV_MW_CI_USER_CNR');
@@ -11,7 +15,7 @@ if ($user === false || $password === false) {
 }
 // --- SESSIONLESS API COMMUNICATION ---
 echo "--- SESSION-LESS API COMMUNICATION ----\n";
-$cl = \CNIC\ClientFactory::getClient([
+$cl = ClientFactory::getClient([
     "registrar" => "CNR" // fka RRPproxy
 ]);
 $cl->useOTESystem() //LIVE System would be used otherwise by default
@@ -24,7 +28,7 @@ print_r($r->getHash());
 
 // --- SESSION BASED API COMMUNICATION ---
 echo "--- SESSION-BASED API COMMUNICATION ----\n";
-$cl = \CNIC\ClientFactory::getClient([
+$cl = ClientFactory::getClient([
     "registrar" => "CNR" // fka RRPproxy
 ]);
 $cl->useOTESystem() //LIVE System would be used otherwise by default

--- a/tests/CNR/bulk_app.php
+++ b/tests/CNR/bulk_app.php
@@ -1,5 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
+use CNIC\ClientFactory;
+
 require __DIR__ . '/../../vendor/autoload.php';
 
 $user = getenv('RTLDEV_MW_CI_USER_CNR');
@@ -18,7 +22,7 @@ if ($rolepassword === false) {
     die("Please provide environment variables RTLDEV_MW_CI_ROLEPASSWORD_CNR.\n");
 }
 
-$cl = \CNIC\ClientFactory::getClient([
+$cl = ClientFactory::getClient([
     "registrar" => "CNR" // fka RRPproxy
 ]);
 $cl->useOTESystem() //LIVE System would be used otherwise by default
@@ -47,7 +51,7 @@ echo "Time: $end1 seconds\n";
 // --- SESSION BASED API COMMUNICATION ---
 echo "--- SESSION-BASED API COMMUNICATION ----\n";
 
-$cl = \CNIC\ClientFactory::getClient([
+$cl = ClientFactory::getClient([
     "registrar" => "CNR" // fka RRPproxy
 ]);
 $cl->useOTESystem() //LIVE System would be used otherwise by default

--- a/tests/ClientFactoryTest.php
+++ b/tests/ClientFactoryTest.php
@@ -7,21 +7,20 @@ namespace CNICTEST;
 
 use CNIC\ClientFactory as CF;
 use CNIC\CNR\Client as CL;
+use CNIC\CNR\SessionClient;
+use PHPUnit\Framework\TestCase;
 
-final class ClientFactoryTest extends \PHPUnit\Framework\TestCase
+final class ClientFactoryTest extends TestCase
 {
-    /**
-     * @var \CNIC\CNR\SessionClient|null $cl
-     */
-    public static $cl;
+    public static ?SessionClient $cl = null;
     /**
      * @var string user name
      */
-    public static $user;
+    public static string $user;
     /**
      * @var string password
      */
-    public static $pw;
+    public static string $pw;
 
     public static function setUpBeforeClass(): void
     {
@@ -32,9 +31,8 @@ final class ClientFactoryTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Basic test for getClient with legacy Registrar HEXONET
-     * @return void
      */
-    public function testHexonetClient()
+    public function testHexonetClient(): void
     {
         $this->expectException(\Exception::class);
         CF::getClient([
@@ -44,9 +42,8 @@ final class ClientFactoryTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Extended Basic test for getClient with Registrar CNR
-     * @return void
      */
-    public function testCNRClient1()
+    public function testCNRClient1(): void
     {
         $cl = CF::getClient([
             "registrar" => "CNR",
@@ -69,9 +66,8 @@ final class ClientFactoryTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Basic test for getClient with Registrar CNR
-     * @return void
      */
-    public function testCNRClient2()
+    public function testCNRClient2(): void
     {
         $cl = CF::getClient([
             "registrar" => "CNR"
@@ -81,9 +77,8 @@ final class ClientFactoryTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Basic test for getClient with invalid Registrar ID
-     * @return void
      */
-    public function testInvalidClient()
+    public function testInvalidClient(): void
     {
         $this->expectException(\Exception::class);
         CF::getClient([

--- a/tests/IBS/ResponseTest.php
+++ b/tests/IBS/ResponseTest.php
@@ -6,8 +6,8 @@ namespace CNICTEST\IBS;
 
 use CNIC\IBS\Response as R;
 use CNIC\IBS\ResponseParser as RP;
-use CNIC\IBS\ResponseTranslator as RT;
 use CNIC\IBS\ResponseTemplateManager as RTM;
+use CNIC\IBS\ResponseTranslator as RT;
 use PHPUnit\Framework\TestCase;
 
 final class ResponseTest extends TestCase

--- a/tests/IBS/app.php
+++ b/tests/IBS/app.php
@@ -1,5 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
+use CNIC\ClientFactory;
+
 require __DIR__ . '/../../vendor/autoload.php';
 
 $user = getenv('RTLDEV_MW_CI_USER_IBS');
@@ -12,7 +16,7 @@ if ($user === false || $password === false) {
 
 // --- SESSIONLESS API COMMUNICATION ---
 echo "--- SESSION-LESS API COMMUNICATION ----\n\n";
-$cl = \CNIC\ClientFactory::getClient([
+$cl = ClientFactory::getClient([
     "registrar" => "IBS"
 ]);
 $cl->useOTESystem()//LIVE System would be used otherwise by default

--- a/tests/MONIKER/app.php
+++ b/tests/MONIKER/app.php
@@ -1,5 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
+use CNIC\ClientFactory;
+
 require __DIR__ . '/../../vendor/autoload.php';
 
 $user = getenv('RTLDEV_MW_CI_USER_MONIKER');
@@ -12,7 +16,7 @@ if ($user === false || $password === false) {
 
 // --- SESSIONLESS API COMMUNICATION ---
 echo "--- SESSION-LESS API COMMUNICATION ----\n\n";
-$cl = \CNIC\ClientFactory::getClient([
+$cl = ClientFactory::getClient([
     "registrar" => "MONIKER"
 ]);
 $cl->useOTESystem()//LIVE System would be used otherwise by default


### PR DESCRIPTION
## Summary

Adds SlevomatCodingStandard rules to PHPCS configuration and fixes all resulting violations across the codebase.

## Changes

### Linter Configuration
- Added `slevomat/coding-standard` ^8.0 with rules for:
  - `declare(strict_types=1)` enforcement
  - Unused imports detection
  - FQN-to-use statement conversion
  - Alphabetical import sorting
  - Typed properties, parameters, and return types
  - Null coalescing operator usage
  - Short list syntax
  - Null-safe object operator
  - Useless parentheses/semicolons removal
- Excluded `PSR12.Files.FileHeader.IncorrectOrder` to avoid conflict with declare placement

### Code Fixes
- Added proper return/parameter type declarations to IBS layer (Response, Client, SocketConfig)
- Removed legacy commented-out `#declare(strict_types=1);` lines
- Replaced FQN class references with proper `use` statements
- Applied Rector auto-fixes for PHP 8.3 modernization
- All `composer lint` (phpcs + phpstan + psalm) passes clean

## JIRA
[RSRMID-2787](https://centralnic.atlassian.net/browse/RSRMID-2787)

[RSRMID-2787]: https://centralnic.atlassian.net/browse/RSRMID-2787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ