### PR TITLE
ci: add permissions blocks and document PHP test matrix [RSRMID-2784]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,13 @@ on:
     branches:
       - master
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  deployments: write
+  id-token: write
+
 jobs:
   release:
     uses: centralnicgroup-opensource/rtldev-middleware-shareable-workflows/.github/workflows/php-sdk-release.yml@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,21 @@ on:
       - opened
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     uses: centralnicgroup-opensource/rtldev-middleware-shareable-workflows/.github/workflows/php-sdk-test.yml@main
     secrets: inherit
+
+  ci-success:
+    needs: tests
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if [ "${{ needs.tests.result }}" != "success" ]; then
+            echo "Tests failed or were cancelled"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ To run the demo application, follow these steps:
    tests/MONIKER/app.php
    ```
 
+## CI / Testing
+
+CI is powered by [reusable GitHub Actions workflows](https://github.com/centralnicgroup-opensource/rtldev-middleware-shareable-workflows). The test matrix covers:
+
+| PHP Version | Status |
+|-------------|--------|
+| 8.3         | ✓      |
+| 8.4         | ✓      |
+| 8.5         | ✓      |
+
+The matrix is configured via the repository variable `RTLDEV_MW_CI_PHP_MATRIX`.
+
 ## Maintainers
 
 * **Kai Schwarz** - [KaiSchwarz-cnic](https://github.com/kaischwarz-cnic)


### PR DESCRIPTION
- Add least-privilege permissions block to test.yml (contents: read)
- Add permissions block to release.yml matching shared workflow needs (contents, issues, pull-requests, deployments, id-token: write)
- Document PHP 8.3/8.4/8.5 test matrix in README

Note: branch protection on master should require status checks to pass before merging to prevent auto-merge without tests (repo settings).