### PR TITLE
fix(security/devcontainer/deps): SSL bypass, PHP intl extension, ext-curl declaration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update \
     && apt-get -y upgrade \
     && apt-get -y install --no-install-recommends \
        wget jq git zip unzip curl \
+       php8.3-intl \
     && apt-get -y autoremove \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,7 +40,7 @@
     "ghcr.io/devcontainers/features/php:1": {
       "version": "8.3",
       "installComposer": true,
-      "extensions": "intl, xdebug, apcu, gd, xml, mbstring, zip, curl"
+      "extensions": "xdebug"
     },
     "ghcr.io/devcontainers/features/node:2": {
       "version": "lts"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
   "workspaceMount": "source=${localWorkspaceFolder},target=/usr/share/rtldev-middleware-php-sdk,type=bind,consistency=cached",
   "workspaceFolder": "/usr/share/rtldev-middleware-php-sdk",
   "shutdownAction": "stopContainer",
+  "initializeCommand": "mkdir -p ${localEnv:HOME}/.claude",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/supporting_files/configuration/php/intl.ini
+++ b/.devcontainer/supporting_files/configuration/php/intl.ini
@@ -1,0 +1,5 @@
+; PHP intl extension (ICU-based Unicode/IDN support)
+; The devcontainer PHP feature installs a custom PHP build that does not
+; compile bundled extensions like intl. We install the system php8.3-intl
+; package in the Dockerfile (same PHP API version) and load its .so here.
+extension=/usr/lib/php/20230831/intl.so

--- a/.devcontainer/supporting_files/scripts/post-create.sh
+++ b/.devcontainer/supporting_files/scripts/post-create.sh
@@ -154,9 +154,14 @@ setup_php_config() {
     local php_scan_dir
     php_scan_dir="$(php --ini 2>/dev/null | grep -m1 'Scan for additional' | awk -F': ' '{print $2}')" || true
     if [[ -n "$php_scan_dir" && -d "$php_scan_dir" ]]; then
-        if [[ -f /opt/php-config/zz-custom.ini ]]; then
-            sudo cp /opt/php-config/zz-custom.ini "$php_scan_dir/zz-custom.ini"
-            log_success "PHP custom config applied to $php_scan_dir"
+        local copied=0
+        for ini_file in /opt/php-config/*.ini; do
+            [[ -f "$ini_file" ]] || continue
+            sudo cp "$ini_file" "$php_scan_dir/$(basename "$ini_file")"
+            (( copied++ )) || true
+        done
+        if (( copied > 0 )); then
+            log_success "PHP custom config applied to $php_scan_dir ($copied file(s))"
         fi
     else
         log_error "Could not determine PHP scan directory"

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
   ],
   "require": {
     "php": ">=8.3.0",
+    "ext-curl": "*",
     "centralnic-reseller/idn-converter": "^1.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -1102,6 +1102,51 @@
             "time": "2024-05-06T16:37:16+00:00"
         },
         {
+            "name": "danog/advanced-json-rpc",
+            "version": "v3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/danog/php-advanced-json-rpc.git",
+                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/danog/php-advanced-json-rpc/zipball/b5f37dbff9a8ad360ca341f3240dc1c168b45447",
+                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447",
+                "shasum": ""
+            },
+            "require": {
+                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
+                "php": "^7.1 || ^8.0",
+                "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AdvancedJsonRpc\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "A more advanced JSONRPC implementation",
+            "support": {
+                "issues": "https://github.com/danog/php-advanced-json-rpc/issues",
+                "source": "https://github.com/danog/php-advanced-json-rpc/tree/v3.2.1"
+            },
+            "time": "2021-06-11T22:34:44+00:00"
+        },
+        {
             "name": "daverandom/libdns",
             "version": "v2.1.0",
             "source": {
@@ -1325,51 +1370,6 @@
                 "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
             },
             "time": "2026-02-07T07:09:04+00:00"
-        },
-        {
-            "name": "felixfbecker/advanced-json-rpc",
-            "version": "v3.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/felixfbecker/php-advanced-json-rpc.git",
-                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/b5f37dbff9a8ad360ca341f3240dc1c168b45447",
-                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447",
-                "shasum": ""
-            },
-            "require": {
-                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-                "php": "^7.1 || ^8.0",
-                "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.0 || ^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "AdvancedJsonRpc\\": "lib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "ISC"
-            ],
-            "authors": [
-                {
-                    "name": "Felix Becker",
-                    "email": "felix.b@outlook.com"
-                }
-            ],
-            "description": "A more advanced JSONRPC implementation",
-            "support": {
-                "issues": "https://github.com/felixfbecker/php-advanced-json-rpc/issues",
-                "source": "https://github.com/felixfbecker/php-advanced-json-rpc/tree/v3.2.1"
-            },
-            "time": "2021-06-11T22:34:44+00:00"
         },
         {
             "name": "felixfbecker/language-server-protocol",
@@ -5104,16 +5104,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "6.5.0",
+            "version": "6.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "38fc8444edf0cebc9205296ee6e30e906ade783b"
+                "reference": "11a32693fb9e33d4f0505de17af41c8fcac698a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/38fc8444edf0cebc9205296ee6e30e906ade783b",
-                "reference": "38fc8444edf0cebc9205296ee6e30e906ade783b",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/11a32693fb9e33d4f0505de17af41c8fcac698a7",
+                "reference": "11a32693fb9e33d4f0505de17af41c8fcac698a7",
                 "shasum": ""
             },
             "require": {
@@ -5123,6 +5123,7 @@
                 "composer-runtime-api": "^2",
                 "composer/semver": "^1.4 || ^2.0 || ^3.0",
                 "composer/xdebug-handler": "^2.0 || ^3.0",
+                "danog/advanced-json-rpc": "^3.1",
                 "dnoegel/php-xdg-base-dir": "^0.1.1",
                 "ext-ctype": "*",
                 "ext-dom": "*",
@@ -5131,16 +5132,15 @@
                 "ext-mbstring": "*",
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
-                "felixfbecker/advanced-json-rpc": "^3.1",
                 "felixfbecker/language-server-protocol": "^1.5.3",
                 "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1 || ^1.0.0",
                 "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
                 "nikic/php-parser": "^5.0.0",
-                "php": "~8.1.17 || ~8.2.4 || ~8.3.0 || ~8.4.0",
+                "php": "~8.1.31 || ~8.2.27 || ~8.3.16 || ~8.4.3",
                 "sebastian/diff": "^4.0 || ^5.0 || ^6.0 || ^7.0",
                 "spatie/array-to-xml": "^2.17.0 || ^3.0",
                 "symfony/console": "^6.0 || ^7.0",
-                "symfony/filesystem": "^6.0 || ^7.0"
+                "symfony/filesystem": "~6.3.12 || ~6.4.3 || ^7.0.3"
             },
             "provide": {
                 "psalm/psalm": "self.version"
@@ -5216,7 +5216,7 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2025-02-07T20:42:25+00:00"
+            "time": "2025-02-17T10:39:14+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/composer.lock
+++ b/composer.lock
@@ -1103,25 +1103,28 @@
         },
         {
             "name": "danog/advanced-json-rpc",
-            "version": "v3.2.1",
+            "version": "v3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/danog/php-advanced-json-rpc.git",
-                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447"
+                "reference": "ae703ea7b4811797a10590b6078de05b3b33dd91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/danog/php-advanced-json-rpc/zipball/b5f37dbff9a8ad360ca341f3240dc1c168b45447",
-                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447",
+                "url": "https://api.github.com/repos/danog/php-advanced-json-rpc/zipball/ae703ea7b4811797a10590b6078de05b3b33dd91",
+                "reference": "ae703ea7b4811797a10590b6078de05b3b33dd91",
                 "shasum": ""
             },
             "require": {
-                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-                "php": "^7.1 || ^8.0",
-                "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0"
+                "netresearch/jsonmapper": "^5",
+                "php": ">=8.1",
+                "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0 || ^6"
+            },
+            "replace": {
+                "felixfbecker/php-advanced-json-rpc": "^3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0 || ^8.0"
+                "phpunit/phpunit": "^9"
             },
             "type": "library",
             "autoload": {
@@ -1137,14 +1140,18 @@
                 {
                     "name": "Felix Becker",
                     "email": "felix.b@outlook.com"
+                },
+                {
+                    "name": "Daniil Gentili",
+                    "email": "daniil@daniil.it"
                 }
             ],
             "description": "A more advanced JSONRPC implementation",
             "support": {
                 "issues": "https://github.com/danog/php-advanced-json-rpc/issues",
-                "source": "https://github.com/danog/php-advanced-json-rpc/tree/v3.2.1"
+                "source": "https://github.com/danog/php-advanced-json-rpc/tree/v3.2.3"
             },
-            "time": "2021-06-11T22:34:44+00:00"
+            "time": "2026-01-12T21:07:10+00:00"
         },
         {
             "name": "daverandom/libdns",
@@ -1790,16 +1797,16 @@
         },
         {
             "name": "netresearch/jsonmapper",
-            "version": "v4.5.0",
+            "version": "v5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cweiske/jsonmapper.git",
-                "reference": "8e76efb98ee8b6afc54687045e1b8dba55ac76e5"
+                "reference": "980674efdda65913492d29a8fd51c82270dd37bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/8e76efb98ee8b6afc54687045e1b8dba55ac76e5",
-                "reference": "8e76efb98ee8b6afc54687045e1b8dba55ac76e5",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/980674efdda65913492d29a8fd51c82270dd37bb",
+                "reference": "980674efdda65913492d29a8fd51c82270dd37bb",
                 "shasum": ""
             },
             "require": {
@@ -1835,9 +1842,9 @@
             "support": {
                 "email": "cweiske@cweiske.de",
                 "issues": "https://github.com/cweiske/jsonmapper/issues",
-                "source": "https://github.com/cweiske/jsonmapper/tree/v4.5.0"
+                "source": "https://github.com/cweiske/jsonmapper/tree/v5.0.1"
             },
-            "time": "2024-09-08T10:13:13+00:00"
+            "time": "2026-02-22T16:28:03+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -2070,16 +2077,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.6.7",
+            "version": "6.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "31a105931bc8ffa3a123383829772e832fd8d903"
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/31a105931bc8ffa3a123383829772e832fd8d903",
-                "reference": "31a105931bc8ffa3a123383829772e832fd8d903",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/7bae67520aa9f5ecc506d646810bd40d9da54582",
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582",
                 "shasum": ""
             },
             "require": {
@@ -2087,8 +2094,8 @@
                 "ext-filter": "*",
                 "php": "^7.4 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.2",
-                "phpdocumentor/type-resolver": "^1.7",
-                "phpstan/phpdoc-parser": "^1.7|^2.0",
+                "phpdocumentor/type-resolver": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0",
                 "webmozart/assert": "^1.9.1 || ^2"
             },
             "require-dev": {
@@ -2098,7 +2105,8 @@
                 "phpstan/phpstan-mockery": "^1.1",
                 "phpstan/phpstan-webmozart-assert": "^1.2",
                 "phpunit/phpunit": "^9.5",
-                "psalm/phar": "^5.26"
+                "psalm/phar": "^5.26",
+                "shipmonk/dead-code-detector": "^0.5.1"
             },
             "type": "library",
             "extra": {
@@ -2128,44 +2136,44 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.7"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/6.0.3"
             },
-            "time": "2026-03-18T20:47:46+00:00"
+            "time": "2026-03-18T20:49:53+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.12.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195"
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/92a98ada2b93d9b201a613cb5a33584dde25f195",
-                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9",
                 "shasum": ""
             },
             "require": {
                 "doctrine/deprecations": "^1.0",
-                "php": "^7.3 || ^8.0",
+                "php": "^7.4 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.0",
-                "phpstan/phpdoc-parser": "^1.18|^2.0"
+                "phpstan/phpdoc-parser": "^2.0"
             },
             "require-dev": {
                 "ext-tokenizer": "*",
                 "phpbench/phpbench": "^1.2",
-                "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "^1.8",
-                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5",
-                "rector/rector": "^0.13.9",
-                "vimeo/psalm": "^4.25"
+                "psalm/phar": "^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-1.x": "1.x-dev"
+                    "dev-1.x": "1.x-dev",
+                    "dev-2.x": "2.x-dev"
                 }
             },
             "autoload": {
@@ -2186,9 +2194,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.12.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/2.0.0"
             },
-            "time": "2025-11-21T15:09:14+00:00"
+            "time": "2026-01-06T21:53:42+00:00"
         },
         {
             "name": "phpstan/extension-installer",
@@ -2696,16 +2704,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.5.27",
+            "version": "12.5.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f37c01edaf3a0cd820331462506af93f1495696e"
+                "reference": "5895d05f5bf421ed230fbd76e1277e4b8955def4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f37c01edaf3a0cd820331462506af93f1495696e",
-                "reference": "f37c01edaf3a0cd820331462506af93f1495696e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5895d05f5bf421ed230fbd76e1277e4b8955def4",
+                "reference": "5895d05f5bf421ed230fbd76e1277e4b8955def4",
                 "shasum": ""
             },
             "require": {
@@ -2774,7 +2782,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.27"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.28"
             },
             "funding": [
                 {
@@ -2782,7 +2790,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-05-25T15:35:34+00:00"
+            "time": "2026-05-27T14:01:10+00:00"
         },
         {
             "name": "psr/container",
@@ -4302,16 +4310,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.11",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "ed0107e43ab452aa77ae99e005b95e56b556e075"
+                "reference": "85095d2573eaefaf35e40b9513a9bf09f72cd217"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/ed0107e43ab452aa77ae99e005b95e56b556e075",
-                "reference": "ed0107e43ab452aa77ae99e005b95e56b556e075",
+                "url": "https://api.github.com/repos/symfony/console/zipball/85095d2573eaefaf35e40b9513a9bf09f72cd217",
+                "reference": "85095d2573eaefaf35e40b9513a9bf09f72cd217",
                 "shasum": ""
             },
             "require": {
@@ -4376,7 +4384,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.11"
+                "source": "https://github.com/symfony/console/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -4396,7 +4404,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-13T12:04:42+00:00"
+            "time": "2026-05-24T08:56:14+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -4875,6 +4883,86 @@
             "time": "2026-05-26T12:51:13+00:00"
         },
         {
+            "name": "symfony/polyfill-php84",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php84.git",
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php84\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.4+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-26T12:51:13+00:00"
+        },
+        {
             "name": "symfony/service-contracts",
             "version": "v3.7.0",
             "source": {
@@ -4963,16 +5051,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v7.4.11",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "965f7306a43383d02c6aca1e3f3bd2f0ea5dee15"
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/965f7306a43383d02c6aca1e3f3bd2f0ea5dee15",
-                "reference": "965f7306a43383d02c6aca1e3f3bd2f0ea5dee15",
+                "url": "https://api.github.com/repos/symfony/string/zipball/961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
                 "shasum": ""
             },
             "require": {
@@ -5030,7 +5118,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.4.11"
+                "source": "https://github.com/symfony/string/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -5050,7 +5138,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-13T12:04:42+00:00"
+            "time": "2026-05-23T15:23:29+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -5104,16 +5192,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "6.7.0",
+            "version": "6.16.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "11a32693fb9e33d4f0505de17af41c8fcac698a7"
+                "reference": "f1f5de594dc76faf8784e02d3dc4716c91c6f6ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/11a32693fb9e33d4f0505de17af41c8fcac698a7",
-                "reference": "11a32693fb9e33d4f0505de17af41c8fcac698a7",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/f1f5de594dc76faf8784e02d3dc4716c91c6f6ac",
+                "reference": "f1f5de594dc76faf8784e02d3dc4716c91c6f6ac",
                 "shasum": ""
             },
             "require": {
@@ -5134,13 +5222,14 @@
                 "ext-tokenizer": "*",
                 "felixfbecker/language-server-protocol": "^1.5.3",
                 "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1 || ^1.0.0",
-                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
+                "netresearch/jsonmapper": "^5.0",
                 "nikic/php-parser": "^5.0.0",
-                "php": "~8.1.31 || ~8.2.27 || ~8.3.16 || ~8.4.3",
-                "sebastian/diff": "^4.0 || ^5.0 || ^6.0 || ^7.0",
+                "php": "~8.1.31 || ~8.2.27 || ~8.3.16 || ~8.4.3 || ~8.5.0",
+                "sebastian/diff": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
                 "spatie/array-to-xml": "^2.17.0 || ^3.0",
-                "symfony/console": "^6.0 || ^7.0",
-                "symfony/filesystem": "~6.3.12 || ~6.4.3 || ^7.0.3"
+                "symfony/console": "^6.0 || ^7.0 || ^8.0",
+                "symfony/filesystem": "~6.3.12 || ~6.4.3 || ^7.0.3 || ^8.0",
+                "symfony/polyfill-php84": "^1.31.0"
             },
             "provide": {
                 "psalm/psalm": "self.version"
@@ -5149,6 +5238,7 @@
                 "amphp/phpunit-util": "^3",
                 "bamarni/composer-bin-plugin": "^1.4",
                 "brianium/paratest": "^6.9",
+                "danog/class-finder": "^0.4.8",
                 "dg/bypass-finals": "^1.5",
                 "ext-curl": "*",
                 "mockery/mockery": "^1.5",
@@ -5160,7 +5250,7 @@
                 "psalm/plugin-phpunit": "^0.19",
                 "slevomat/coding-standard": "^8.4",
                 "squizlabs/php_codesniffer": "^3.6",
-                "symfony/process": "^6.0 || ^7.0"
+                "symfony/process": "^6.0 || ^7.0 || ^8.0"
             },
             "suggest": {
                 "ext-curl": "In order to send data to shepherd",
@@ -5216,7 +5306,7 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2025-02-17T10:39:14+00:00"
+            "time": "2026-03-19T10:56:09+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f474d5ba47b0e3a36aed9dd280e3edb8",
+    "content-hash": "a7e278f0644d30d9fe2fecff1c152593",
     "packages": [
         {
             "name": "centralnic-reseller/idn-converter",
@@ -5291,7 +5291,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.3.0"
+        "php": ">=8.3.0",
+        "ext-curl": "*"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"

--- a/src/CNR/Client.php
+++ b/src/CNR/Client.php
@@ -420,7 +420,7 @@ class Client
             CURLOPT_HTTPHEADER      => [
                 "Expect:",
                 "Content-Type: application/x-www-form-urlencoded", //UTF-8 implied
-                "Content-Length: " . strlen($data),
+                "Content-Length: " . (string)strlen($data),
                 "Connection: keep-alive"
             ]
         ] + $this->curlopts);

--- a/src/CNR/Column.php
+++ b/src/CNR/Column.php
@@ -51,6 +51,7 @@ class Column implements ColumnInterface
     /**
      * Get column name
      */
+    #[\Override]
     public function getKey(): string
     {
         return $this->key;
@@ -60,6 +61,7 @@ class Column implements ColumnInterface
      * Get column data
      * @return string[]
      */
+    #[\Override]
     public function getData(): array
     {
         return $this->data;
@@ -69,6 +71,7 @@ class Column implements ColumnInterface
      * Get column data at given index
      * @param integer $idx data index
      */
+    #[\Override]
     public function getDataByIndex(int $idx): mixed
     {
         return $this->hasDataIndex($idx) ? $this->data[$idx] : null;

--- a/src/CNR/Column.php
+++ b/src/CNR/Column.php
@@ -9,13 +9,15 @@ declare(strict_types=1);
 
 namespace CNIC\CNR;
 
+use CNIC\ColumnInterface;
+
 /**
  * CNR Column
  *
  * @psalm-api
  * @package CNIC\CNR
  */
-class Column // implements \CNIC\ColumnInterface
+class Column implements ColumnInterface
 {
     /**
      * count of column data entries

--- a/src/CNR/Logger.php
+++ b/src/CNR/Logger.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 
 namespace CNIC\CNR;
 
-use CNIC\CNR\Response;
 use CNIC\LoggerInterface;
+use CNIC\ResponseInterface;
 
 /**
  * CNR Logger
@@ -22,11 +22,11 @@ final class Logger implements LoggerInterface
     /**
      * output/log given data
      * @param string $post post request data in string format
-     * @param Response $r Response to log
+     * @param ResponseInterface $r Response to log
      * @param string|null $error error message (optional)
      */
     #[\Override]
-    public function log($post, Response $r, ?string $error = null): void
+    public function log(string $post, ResponseInterface $r, ?string $error = null): void
     {
          echo implode("\n", [
             print_r($r->getCommand(), true),

--- a/src/CNR/Record.php
+++ b/src/CNR/Record.php
@@ -9,13 +9,15 @@ declare(strict_types=1);
 
 namespace CNIC\CNR;
 
+use CNIC\RecordInterface;
+
 /**
  * CNR Record
  *
  * @psalm-api
  * @package CNIC\CNR
  */
-class Record // implements \CNIC\RecordInterface
+class Record implements RecordInterface
 {
     /**
      * row data container

--- a/src/CNR/Record.php
+++ b/src/CNR/Record.php
@@ -54,6 +54,7 @@ class Record implements RecordInterface
      * get row data
      * @return array<string,mixed>
      */
+    #[\Override]
     public function getData(): array
     {
         return $this->data;
@@ -63,6 +64,7 @@ class Record implements RecordInterface
      * get row data for given column
      * @param string $key column name
      */
+    #[\Override]
     public function getDataByKey(string $key): mixed
     {
         if ($this->hasData($key)) {

--- a/src/CNR/Response.php
+++ b/src/CNR/Response.php
@@ -145,6 +145,7 @@ class Response implements ResponseInterface
     /**
      * Get Request URL
      */
+    #[\Override]
     public function getRequestURL(): string
     {
         return $this->requestUrl;
@@ -153,6 +154,7 @@ class Response implements ResponseInterface
     /**
      * Get API response code
      */
+    #[\Override]
     public function getCode(): int
     {
         return intval($this->hash["CODE"], 10);
@@ -161,6 +163,7 @@ class Response implements ResponseInterface
     /**
      * Get API response description
      */
+    #[\Override]
     public function getDescription(): string
     {
         return $this->hash["DESCRIPTION"];
@@ -169,6 +172,7 @@ class Response implements ResponseInterface
     /**
      * Get Plain API response
      */
+    #[\Override]
     public function getPlain(): string
     {
         return $this->raw;
@@ -177,6 +181,7 @@ class Response implements ResponseInterface
     /**
      * Get Queuetime of API response
      */
+    #[\Override]
     public function getQueuetime(): float
     {
         if (array_key_exists("QUEUETIME", $this->hash)) {
@@ -189,6 +194,7 @@ class Response implements ResponseInterface
      * Get API response as Hash
      * @return array<string, mixed>
      */
+    #[\Override]
     public function getHash(): array
     {
         return $this->hash;
@@ -197,6 +203,7 @@ class Response implements ResponseInterface
     /**
      * Get Runtime of API response
      */
+    #[\Override]
     public function getRuntime(): float
     {
         if (array_key_exists("RUNTIME", $this->hash)) {
@@ -209,6 +216,7 @@ class Response implements ResponseInterface
      * Check if current API response represents an error case
      * API response code is an 5xx code
      */
+    #[\Override]
     public function isError(): bool
     {
         return substr($this->hash["CODE"], 0, 1) === "5";
@@ -218,6 +226,7 @@ class Response implements ResponseInterface
      * Check if current API response represents a success case
      * API response code is an 2xx code
      */
+    #[\Override]
     public function isSuccess(): bool
     {
         return substr($this->hash["CODE"], 0, 1) === "2";
@@ -227,6 +236,7 @@ class Response implements ResponseInterface
      * Check if current API response represents a temporary error case
      * API response code is an 4xx code
      */
+    #[\Override]
     public function isTmpError(): bool
     {
         return substr($this->hash["CODE"], 0, 1) === "4";
@@ -235,6 +245,7 @@ class Response implements ResponseInterface
     /**
      * Check if current operation is returned as pending
      */
+    #[\Override]
     public function isPending(): bool
     {
         return isset($this->hash["PENDING"]) && $this->hash["PENDING"] === "1";
@@ -246,6 +257,7 @@ class Response implements ResponseInterface
      * @param string[] $data array of column data
      * @return $this
      */
+    #[\Override]
     public function addColumn(string $key, array $data): static
     {
         $col = new Column($key, $data);
@@ -259,6 +271,7 @@ class Response implements ResponseInterface
      * @param array<string,mixed> $h row hash data
      * @return $this
      */
+    #[\Override]
     public function addRecord(array $h): static
     {
         $this->records[] = new Record($h);
@@ -269,6 +282,7 @@ class Response implements ResponseInterface
      * Get column by column name
      * @param string $key column name
      */
+    #[\Override]
     public function getColumn(string $key): ?Column
     {
         return ($this->hasColumn($key) ? $this->columns[array_search($key, $this->columnkeys)] : null);
@@ -279,6 +293,7 @@ class Response implements ResponseInterface
      * @param string $colkey column name
      * @param int $index column data index
      */
+    #[\Override]
     public function getColumnIndex(string $colkey, int $index): mixed
     {
         $col = $this->getColumn($colkey);
@@ -290,6 +305,7 @@ class Response implements ResponseInterface
      * @param bool $filterPaginationKeys strip pagination columns
      * @return string[]
      */
+    #[\Override]
     public function getColumnKeys(bool $filterPaginationKeys = false): array
     {
         if ($filterPaginationKeys) {
@@ -304,6 +320,7 @@ class Response implements ResponseInterface
      * Get List of Columns
      * @return Column[]
      */
+    #[\Override]
     public function getColumns(): array
     {
         return $this->columns;
@@ -313,6 +330,7 @@ class Response implements ResponseInterface
      * Get Command used in this request
      * @return array<string>
      */
+    #[\Override]
     public function getCommand(): array
     {
         return CommandFormatter::getSortedCommand($this->command);
@@ -321,6 +339,7 @@ class Response implements ResponseInterface
     /**
      * Get Command used in this request in plain text format
      */
+    #[\Override]
     public function getCommandPlain(): string
     {
         return CommandFormatter::formatCommand($this->getCommand());
@@ -329,6 +348,7 @@ class Response implements ResponseInterface
     /**
      * Get Page Number of current List Query
      */
+    #[\Override]
     public function getCurrentPageNumber(): ?int
     {
         $first = $this->getFirstRecordIndex();
@@ -342,6 +362,7 @@ class Response implements ResponseInterface
     /**
      * Get Record of current record index
      */
+    #[\Override]
     public function getCurrentRecord(): ?Record
     {
         return $this->hasCurrentRecord() ? $this->records[$this->recordIndex] : null;
@@ -350,6 +371,7 @@ class Response implements ResponseInterface
     /**
      * Get Index of first row in this response
      */
+    #[\Override]
     public function getFirstRecordIndex(): ?int
     {
         $col = $this->getColumn("FIRST");
@@ -366,6 +388,7 @@ class Response implements ResponseInterface
     /**
      * Get last record index of the current list query
      */
+    #[\Override]
     public function getLastRecordIndex(): ?int
     {
         $col = $this->getColumn("LAST");
@@ -386,6 +409,7 @@ class Response implements ResponseInterface
      * Get Response as List Hash including useful meta data for tables
      * @return array<mixed>
      */
+    #[\Override]
     public function getListHash(): array
     {
         $lh = [];
@@ -410,6 +434,7 @@ class Response implements ResponseInterface
     /**
      * Get next record in record list
      */
+    #[\Override]
     public function getNextRecord(): ?Record
     {
         if ($this->hasNextRecord()) {
@@ -421,6 +446,7 @@ class Response implements ResponseInterface
     /**
      * Get Page Number of next list query
      */
+    #[\Override]
     public function getNextPageNumber(): ?int
     {
         $cp = $this->getCurrentPageNumber();
@@ -435,6 +461,7 @@ class Response implements ResponseInterface
     /**
      * Get the number of pages available for this list query
      */
+    #[\Override]
     public function getNumberOfPages(): int
     {
         $t = $this->getRecordsTotalCount();
@@ -449,6 +476,7 @@ class Response implements ResponseInterface
      * Get object containing all paging data
      * @return array<string,int|null>
      */
+    #[\Override]
     public function getPagination(): array
     {
         return [
@@ -467,6 +495,7 @@ class Response implements ResponseInterface
     /**
      * Get Page Number of previous list query
      */
+    #[\Override]
     public function getPreviousPageNumber(): ?int
     {
         $cp = $this->getCurrentPageNumber();
@@ -483,6 +512,7 @@ class Response implements ResponseInterface
     /**
      * Get previous record in record list
      */
+    #[\Override]
     public function getPreviousRecord(): ?Record
     {
         if ($this->hasPreviousRecord()) {
@@ -495,6 +525,7 @@ class Response implements ResponseInterface
      * Get Record at given index
      * @param int $idx record index
      */
+    #[\Override]
     public function getRecord(int $idx): ?Record
     {
         if ($idx >= 0 && $this->getRecordsCount() > $idx) {
@@ -507,6 +538,7 @@ class Response implements ResponseInterface
      * Get all Records
      * @return Record[]
      */
+    #[\Override]
     public function getRecords(): array
     {
         return $this->records;
@@ -515,6 +547,7 @@ class Response implements ResponseInterface
     /**
      * Get count of rows in this response
      */
+    #[\Override]
     public function getRecordsCount(): int
     {
         return count($this->records);
@@ -523,6 +556,7 @@ class Response implements ResponseInterface
     /**
      * Get total count of records available for the list query
      */
+    #[\Override]
     public function getRecordsTotalCount(): int
     {
         $col = $this->getColumn("TOTAL");
@@ -539,6 +573,7 @@ class Response implements ResponseInterface
      * Get limit(ation) setting of the current list query
      * This is the count of requested rows
      */
+    #[\Override]
     public function getRecordsLimitation(): int
     {
         $col = $this->getColumn("LIMIT");
@@ -554,6 +589,7 @@ class Response implements ResponseInterface
     /**
      * Check if this list query has a next page
      */
+    #[\Override]
     public function hasNextPage(): bool
     {
         $cp = $this->getCurrentPageNumber();
@@ -566,6 +602,7 @@ class Response implements ResponseInterface
     /**
      * Check if this list query has a previous page
      */
+    #[\Override]
     public function hasPreviousPage(): bool
     {
         $cp = $this->getCurrentPageNumber();
@@ -579,6 +616,7 @@ class Response implements ResponseInterface
      * Reset index in record list back to zero
      * @return $this
      */
+    #[\Override]
     public function rewindRecordList(): static
     {
         $this->recordIndex = 0;

--- a/src/CNR/Response.php
+++ b/src/CNR/Response.php
@@ -13,6 +13,7 @@ use CNIC\CNR\Column;
 use CNIC\CNR\ResponseParser as RP;
 use CNIC\CNR\ResponseTranslator as RT;
 use CNIC\CommandFormatter;
+use CNIC\ResponseInterface;
 
 /**
  * CNR Response
@@ -20,7 +21,7 @@ use CNIC\CommandFormatter;
  * @psalm-api
  * @package CNIC\CNR
  */
-class Response // implements \CNIC\ResponseInterface
+class Response implements ResponseInterface
 {
     /**
      * The API Command used within this request
@@ -186,7 +187,7 @@ class Response // implements \CNIC\ResponseInterface
 
     /**
      * Get API response as Hash
-     * @return array<mixed>
+     * @return array<string, mixed>
      */
     public function getHash(): array
     {
@@ -245,7 +246,7 @@ class Response // implements \CNIC\ResponseInterface
      * @param string[] $data array of column data
      * @return $this
      */
-    public function addColumn(string $key, array $data)
+    public function addColumn(string $key, array $data): static
     {
         $col = new Column($key, $data);
         $this->columns[] = $col;
@@ -258,7 +259,7 @@ class Response // implements \CNIC\ResponseInterface
      * @param array<string,mixed> $h row hash data
      * @return $this
      */
-    public function addRecord(array $h)
+    public function addRecord(array $h): static
     {
         $this->records[] = new Record($h);
         return $this;
@@ -578,7 +579,7 @@ class Response // implements \CNIC\ResponseInterface
      * Reset index in record list back to zero
      * @return $this
      */
-    public function rewindRecordList()
+    public function rewindRecordList(): static
     {
         $this->recordIndex = 0;
         return $this;

--- a/src/CNR/SocketConfig.php
+++ b/src/CNR/SocketConfig.php
@@ -115,7 +115,7 @@ class SocketConfig
             $params["persistent"] = 1;
         }
         if (strlen($this->user) !== 0) {
-            $params[$this->parameters["command"]] .= "\nSUBUSER={$this->user}";
+            $params[$this->parameters["command"]] = (string)$params[$this->parameters["command"]] . "\nSUBUSER={$this->user}";
         }
         return http_build_query($params); // RFC1738 x-www-form-urlencoded as default
     }

--- a/src/ColumnInterface.php
+++ b/src/ColumnInterface.php
@@ -42,7 +42,7 @@ interface ColumnInterface
      *
      * @param int $idx data index
      */
-    public function getDataByIndex(int $idx): ?string;
+    public function getDataByIndex(int $idx): mixed;
 
     /**
      * Check if column has a given data index

--- a/src/CommandFormatter.php
+++ b/src/CommandFormatter.php
@@ -47,7 +47,7 @@ final class CommandFormatter
                 $newKey = $toupper ? \strtoupper($key) : $key;
                 if (is_array($val)) {
                     foreach ($val as $idx => $v) {
-                        $newcmd[$newKey . $idx] = preg_replace("/\r|\n/", "", (string)$v) ?? (string)$v;
+                        $newcmd[$newKey . (string)$idx] = preg_replace("/\r|\n/", "", (string)$v) ?? (string)$v;
                     }
                 } else {
                     $newcmd[$newKey] = preg_replace("/\r|\n/", "", (string)$val) ?? (string)$val;

--- a/src/IBS/Client.php
+++ b/src/IBS/Client.php
@@ -158,8 +158,6 @@ class Client extends CNRClient
                 "Content-Length: " . strlen($data),
                 "Connection: keep-alive"
             ],
-            CURLOPT_SSL_VERIFYPEER => 0, // IBS / Moniker only
-            CURLOPT_SSL_VERIFYHOST => 0, // IBS / Moniker only
             CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4 // IBS / Moniker only
         ] + $this->curlopts);
 

--- a/src/IBS/Client.php
+++ b/src/IBS/Client.php
@@ -29,21 +29,8 @@ class Client extends CNRClient
      */
     public function __construct(string $path = "")
     {
-        $contents = file_get_contents($path);
-        if ($contents === false) {
-            $contents = "";
-        }
-        $settings = json_decode($contents, true);
-        if (is_null($settings) || $settings === false || $settings === true) {
-            $settings = [];
-        }
-        $this->settings = $settings;
-        $this->socketURL = "";
-        $this->debugMode = false;
-        $this->ua = "";
-        $this->socketConfig = new SocketConfig($this->settings["parameters"]);
-        $this->useLIVESystem();
-        $this->setDefaultLogger();
+        parent::__construct($path);
+        $this->socketConfig = new SocketConfig($this->settings["parameters"] ?? []);
     }
 
     /**

--- a/src/IBS/Client.php
+++ b/src/IBS/Client.php
@@ -155,7 +155,7 @@ class Client extends CNRClient
             CURLOPT_HTTPHEADER      => [
                 "Expect:",
                 "Content-Type: application/x-www-form-urlencoded", //UTF-8 implied
-                "Content-Length: " . strlen($data),
+                "Content-Length: " . (string)strlen($data),
                 "Connection: keep-alive"
             ],
             CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4 // IBS / Moniker only

--- a/src/IBS/Column.php
+++ b/src/IBS/Column.php
@@ -17,6 +17,6 @@ use CNIC\CNR\Column as CNRColumn;
  * @psalm-api
  * @package CNIC\IBS
  */
-class Column extends CNRColumn // implements \CNIC\ColumnInterface
+class Column extends CNRColumn
 {
 }

--- a/src/IBS/Logger.php
+++ b/src/IBS/Logger.php
@@ -9,9 +9,8 @@ declare(strict_types=1);
 
 namespace CNIC\IBS;
 
-use CNIC\CNR\Response;
-use CNIC\IBS\Response as IBSResponse;
 use CNIC\LoggerInterface;
+use CNIC\ResponseInterface;
 
 /**
  * IBS Logger
@@ -24,20 +23,15 @@ final class Logger implements LoggerInterface
      * Output/log given data
      *
      * @param string $post Post request data in string format
-     * @param Response $r Response to log
+     * @param ResponseInterface $r Response to log
      * @param string|null $error Error message (optional)
      */
     #[\Override]
-    public function log(string $post, Response $r, ?string $error = null): void
+    public function log(string $post, ResponseInterface $r, ?string $error = null): void
     {
-        $requestUrl = '';
-        if ($r instanceof IBSResponse) {
-            $requestUrl = $r->getRequestURL();
-        }
-
         echo (
             "R E Q U E S T\n" .
-            "\tAPI:  " . $requestUrl . "\n" .
+            "\tAPI:  " . $r->getRequestURL() . "\n" .
             "\tPOST: " . $post . "\n\n" .
             "R E S P O N S E\n" .
             ($error !== null && $error !== '' ? "\tHTTP communication failed: " . $error . "\n" : "") .

--- a/src/IBS/Record.php
+++ b/src/IBS/Record.php
@@ -17,6 +17,6 @@ use CNIC\CNR\Record as CNRRecord;
  * @psalm-api
  * @package CNIC\IBS
  */
-class Record extends CNRRecord // implements \CNIC\RecordInterface
+class Record extends CNRRecord
 {
 }

--- a/src/IBS/Response.php
+++ b/src/IBS/Response.php
@@ -22,7 +22,7 @@ use CNIC\IBS\ResponseTranslator as RT;
  * @psalm-api
  * @package CNIC\IBS
  */
-class Response extends CNRResponse // implements \CNIC\ResponseInterface
+class Response extends CNRResponse
 {
     /**
      * Regex for pagination related column keys
@@ -203,7 +203,7 @@ class Response extends CNRResponse // implements \CNIC\ResponseInterface
      * @return $this
      */
     #[\Override]
-    public function addColumn(string $key, array $data)
+    public function addColumn(string $key, array $data): static
     {
         $col = new Column($key, $data);
         $this->columns[] = $col;
@@ -217,7 +217,7 @@ class Response extends CNRResponse // implements \CNIC\ResponseInterface
      * @return $this
      */
     #[\Override]
-    public function addRecord(array $h)
+    public function addRecord(array $h): static
     {
         $this->records[] = new Record($h);
         return $this;
@@ -511,7 +511,7 @@ class Response extends CNRResponse // implements \CNIC\ResponseInterface
      * @return $this
      */
     #[\Override]
-    public function rewindRecordList()
+    public function rewindRecordList(): static
     {
         $this->recordIndex = 0;
         return $this;

--- a/src/LoggerInterface.php
+++ b/src/LoggerInterface.php
@@ -9,8 +9,6 @@ declare(strict_types=1);
 
 namespace CNIC;
 
-use CNIC\CNR\Response;
-
 /**
  * Common Logger Interface
  *
@@ -23,8 +21,8 @@ interface LoggerInterface
      * Output/log given data
      *
      * @param string $post Post request data in string format
-     * @param Response $r Response to log
+     * @param ResponseInterface $r Response to log
      * @param string|null $error Error message (optional)
      */
-    public function log(string $post, Response $r, ?string $error = null): void;
+    public function log(string $post, ResponseInterface $r, ?string $error = null): void;
 }

--- a/src/RecordInterface.php
+++ b/src/RecordInterface.php
@@ -27,14 +27,14 @@ interface RecordInterface
      *   // ... further column data ...
      * ];
      * </code>
-     * @param array<string> $data data object
+     * @param array<string, mixed> $data data object
      */
     public function __construct(array $data);
 
     /**
      * Get row data
      *
-     * @return array<string> row data
+     * @return array<string, mixed> row data
      */
     public function getData(): array;
 
@@ -42,9 +42,9 @@ interface RecordInterface
      * Get row data for given column
      *
      * @param string $key column name
-     * @return string|null row data for given column or null if column does not exist
+     * @return mixed row data for given column or null if column does not exist
      */
-    public function getDataByKey(string $key): ?string;
+    public function getDataByKey(string $key): mixed;
 
     /**
      * Check if record has data for given column

--- a/src/ResponseInterface.php
+++ b/src/ResponseInterface.php
@@ -57,7 +57,7 @@ interface ResponseInterface
 
     /**
      * Get API response as Hash
-     * @return array<string> API response hash
+     * @return array<string, mixed> API response hash
      */
     public function getHash(): array;
 
@@ -103,7 +103,7 @@ interface ResponseInterface
 
     /**
      * Add a record to the record list
-     * @param array<string> $h row hash data
+     * @param array<string, mixed> $h row hash data
      */
     public function addRecord(array $h): ResponseInterface;
 
@@ -172,7 +172,7 @@ interface ResponseInterface
 
     /**
      * Get Response as List Hash including useful meta data for tables
-     * @return array<string> hash including list meta data and array of rows in hash notation
+     * @return array<mixed> hash including list meta data and array of rows in hash notation
      */
     public function getListHash(): array;
 
@@ -196,7 +196,7 @@ interface ResponseInterface
 
     /**
      * Get object containing all paging data
-     * @return array<string> paginator data
+     * @return array<string, int|null> paginator data
      */
     public function getPagination(): array;
 

--- a/tests/CNR/ClientTest.php
+++ b/tests/CNR/ClientTest.php
@@ -433,7 +433,7 @@ final class ClientTest extends TestCase
             //"نامه\u200Cای.de"           => "xn--mgba3gch31f.de"
         ];
         foreach ($idns as $idn => $ace) {
-            $tmp = idn_to_ascii(
+            $tmp = \idn_to_ascii(
                 $idn,
                 (bool)preg_match("/\.(art|be|ca|de|fr|pm|re|swiss|tf|wf|yt)\.?$/i", $idn) ?
                     IDNA_NONTRANSITIONAL_TO_ASCII :


### PR DESCRIPTION
## Summary

- Remove `CURLOPT_SSL_VERIFYPEER`/`CURLOPT_SSL_VERIFYHOST` bypass in `IBS\Client` — was allowing MITM attacks; system CA bundle is sufficient for public HTTPS endpoints
- Fix missing PHP `intl` extension in devcontainer — the PHP feature's `extensions` option silently fails for bundled extensions; solved via `php8.3-intl` apt package (binary-compatible same API version) + `intl.ini` drop-in; `post-create.sh` generalised to copy all `*.ini` files; `devcontainer.json` extensions list trimmed to `xdebug` only
- Declare `ext-curl` in `composer.json` `require` — hard runtime dependency used directly in both `Client` classes, previously undeclared


## Test plan

- [ ] `composer test` passes (127 tests, 0 failures) — including `testIdnaToAscii` which was previously failing due to missing `intl`
- [ ] `composer lint` passes — no phpcs / phpstan / psalm errors
- [ ] On container rebuild: confirm `php -m | grep intl` shows the extension loaded