### PR TITLE
docs(CLAUDE.md): formally implement interfaces — update stale caveat (RSRMID-2801)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This is the **PHP SDK** for Team Internet backend APIs (CentralNic Reseller, Int
 - **Namespace root:** `CNIC\` mapped to `src/` (PSR-4)
 - **Inheritance chain:** `CNR\Client` → `CNR\SessionClient` → `IBS\Client` → `IBS\SessionClient` → `MONIKER\SessionClient`
 - **Config-driven:** Each sub-namespace has a `config.json` with API URLs, parameter mappings, and feature flags
-- **Interfaces:** `ColumnInterface`, `RecordInterface`, `ResponseInterface`, `LoggerInterface` define contracts (implementations don't formally `implements` them yet)
+- **Interfaces:** `ColumnInterface`, `RecordInterface`, `ResponseInterface`, `LoggerInterface` define contracts; all concrete classes formally declare `implements`
 - **Factory pattern:** `ClientFactory::getClient()` for instantiation
 
 ## Coding Standards
@@ -79,14 +79,14 @@ composer phpstan       # Static analysis
 
 ## Important Files
 
-| Path | Purpose |
-|------|---------|
-| `src/CNR/config.json` | CNR API endpoints and settings |
-| `src/IBS/config.json` | IBS API endpoints and settings |
-| `src/MONIKER/config.json` | Moniker API endpoints and settings |
-| `.github/linters/phpcs.xml` | CodeSniffer PSR-12 config |
-| `.github/linters/phpstan.neon` | PHPStan level 8 config |
-| `phpunit.xml` | PHPUnit configuration |
+| Path                           | Purpose                            |
+| ------------------------------ | ---------------------------------- |
+| `src/CNR/config.json`          | CNR API endpoints and settings     |
+| `src/IBS/config.json`          | IBS API endpoints and settings     |
+| `src/MONIKER/config.json`      | Moniker API endpoints and settings |
+| `.github/linters/phpcs.xml`    | CodeSniffer PSR-12 config          |
+| `.github/linters/phpstan.neon` | PHPStan level 8 config             |
+| `phpunit.xml`                  | PHPUnit configuration              |
 
 ## Atlassian / JIRA
 


### PR DESCRIPTION
## Summary

- All concrete classes (`CNR\Column`, `CNR\Record`, `CNR\Response`, `CNR\Logger`, `IBS\Logger`) already declare `implements` for their respective interfaces — this was completed as part of the prior OOP modernisation work.
- `composer phpstan`, `composer psalm`, and `composer lint` all pass cleanly with zero errors; no signature mismatches exist.
- Removes the stale CLAUDE.md note _"implementations don't formally `implements` them yet"_ and replaces it with the accurate statement.

## Test plan

- [x] `composer phpstan` — no errors
- [x] `composer psalm` — no errors
- [x] `composer lint` — no errors

Closes RSRMID-2801

🤖 Generated with [Claude Code](https://claude.com/claude-code)