### PR TITLE
ci(lint): add composer audit job for dependency CVE scanning

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
           extra_args: --only-verified
 
   actionlint:
-    name: Lint GitHub Actions
+    name: "Lint: GitHub Actions"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -44,7 +44,7 @@ jobs:
           reporter: github-pr-review
 
   hadolint:
-    name: Lint Dockerfile
+    name: "Lint: Dockerfile"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -53,7 +53,7 @@ jobs:
           dockerfile: .devcontainer/Dockerfile
 
   shellcheck:
-    name: ShellCheck
+    name: "Lint: ShellCheck"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -67,7 +67,7 @@ jobs:
         run: composer shellcheck
 
   phpcs:
-    name: PHP CodeSniffer
+    name: "Lint: PHP CodeSniffer"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -81,7 +81,7 @@ jobs:
         run: composer phpcs
 
   phpstan:
-    name: PHPStan
+    name: "Lint: PHPStan"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -95,7 +95,7 @@ jobs:
         run: composer phpstan
 
   psalm:
-    name: Psalm
+    name: "Lint: PHP Psalm"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,9 +23,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: ludeeus/action-shellcheck@master
+      - uses: shivammathur/setup-php@v2
         with:
-          scandir: ".devcontainer/supporting_files/scripts"
+          php-version: ${{ vars.RTLDEV_MW_CI_PHP_VERSION }}
+          coverage: none
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+      - name: ShellCheck
+        run: composer shellcheck
 
   hadolint:
     name: Lint Dockerfile
@@ -54,9 +59,51 @@ jobs:
       - uses: actions/checkout@v6
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.3"
+          php-version: ${{ vars.RTLDEV_MW_CI_PHP_VERSION }}
           coverage: none
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist --no-progress
       - name: Audit PHP dependencies
         run: composer audit --no-dev
+
+  phpcs:
+    name: PHP CodeSniffer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ vars.RTLDEV_MW_CI_PHP_VERSION }}
+          coverage: none
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+      - name: PHP CodeSniffer
+        run: composer phpcs
+
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ vars.RTLDEV_MW_CI_PHP_VERSION }}
+          coverage: none
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+      - name: PHPStan
+        run: composer phpstan
+
+  psalm:
+    name: Psalm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ vars.RTLDEV_MW_CI_PHP_VERSION }}
+          coverage: none
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+      - name: Psalm
+        run: composer psalm

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,20 @@ permissions:
   contents: read
 
 jobs:
+  composer-audit:
+    name: PHP Dependency Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ vars.RTLDEV_MW_CI_PHP_VERSION }}
+          coverage: none
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+      - name: Audit PHP dependencies
+        run: composer audit --no-dev
+
   actionlint:
     name: Lint GitHub Actions
     runs-on: ubuntu-latest
@@ -51,20 +65,6 @@ jobs:
       - uses: trufflesecurity/trufflehog@main
         with:
           extra_args: --only-verified
-
-  composer-audit:
-    name: PHP Dependency Audit
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ vars.RTLDEV_MW_CI_PHP_VERSION }}
-          coverage: none
-      - name: Install dependencies
-        run: composer install --no-interaction --prefer-dist --no-progress
-      - name: Audit PHP dependencies
-        run: composer audit --no-dev
 
   phpcs:
     name: PHP CodeSniffer

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   composer-audit:
-    name: PHP Dependency Audit
+    name: "Audit: PHP Dependencies"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,3 +46,17 @@ jobs:
       - uses: trufflesecurity/trufflehog@main
         with:
           extra_args: --only-verified
+
+  composer-audit:
+    name: PHP Dependency Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+          coverage: none
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+      - name: Audit PHP dependencies
+        run: composer audit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,17 @@ jobs:
       - name: Audit PHP dependencies
         run: composer audit --no-dev
 
+  trufflehog:
+    name: "Audit: Secret Scanning"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: trufflesecurity/trufflehog@main
+        with:
+          extra_args: --only-verified
+
   actionlint:
     name: Lint GitHub Actions
     runs-on: ubuntu-latest
@@ -31,6 +42,15 @@ jobs:
       - uses: reviewdog/action-actionlint@v1
         with:
           reporter: github-pr-review
+
+  hadolint:
+    name: Lint Dockerfile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: hadolint/hadolint-action@v3.3.0
+        with:
+          dockerfile: .devcontainer/Dockerfile
 
   shellcheck:
     name: ShellCheck
@@ -45,26 +65,6 @@ jobs:
         run: composer install --no-interaction --prefer-dist --no-progress
       - name: ShellCheck
         run: composer shellcheck
-
-  hadolint:
-    name: Lint Dockerfile
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: hadolint/hadolint-action@v3.3.0
-        with:
-          dockerfile: .devcontainer/Dockerfile
-
-  trufflehog:
-    name: Secret Scanning
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - uses: trufflesecurity/trufflehog@main
-        with:
-          extra_args: --only-verified
 
   phpcs:
     name: PHP CodeSniffer

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,4 +59,4 @@ jobs:
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist --no-progress
       - name: Audit PHP dependencies
-        run: composer audit
+        run: composer audit --no-dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,10 @@
 name: Dependabot auto-merge & tests
 "on":
-  pull_request:
+  workflow_run:
+    workflows:
+      - Lint & Security
     types:
-      - opened
-      - synchronize
+      - completed
 
 permissions:
   contents: write
@@ -11,7 +12,10 @@ permissions:
 
 jobs:
   tests:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: centralnicgroup-opensource/rtldev-middleware-shareable-workflows/.github/workflows/php-sdk-test.yml@main
+    with:
+      ref: ${{ github.event.workflow_run.head_sha }}
     secrets: inherit
 
   ci-success:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ composer test          # PHPUnit with coverage
 composer lint          # PHP CodeSniffer
 composer codefix       # Auto-fix coding standard violations
 composer phpstan       # Static analysis
+composer audit         # Check dependencies for known CVEs (Composer 2.4+)
 ```
 
 ## Git Conventions


### PR DESCRIPTION
## Summary

This PR introduces \`composer audit\` as a CI security gate and takes the opportunity to consolidate all linting into \`lint.yml\`, establishing a clean sequential pipeline where tests only run after linting succeeds.

### \`lint.yml\` — single source of truth for linting

- Adds \`composer audit --no-dev\` as a security gate — scans production dependencies against the PHP Security Advisories Database, fails CI on any known CVE. Dev tooling (PHPStan, PHPUnit, Psalm, etc.) is excluded as it is never shipped to consumers
- Adds \`phpcs\`, \`phpstan\`, \`psalm\` as separate parallel jobs, replacing the \`composer lint\` bundle in the shared workflow
- Replaces \`ludeeus/action-shellcheck\` (scoped to \`.devcontainer\`) with \`composer shellcheck\` for consistent project-wide shell script coverage
- Aligns all PHP-setup jobs to \`vars.RTLDEV_MW_CI_PHP_VERSION\`
- Applies consistent \`Audit:\` / \`Lint:\` prefixes to all check names for a readable CI checks list:
  1. **Audit: PHP Dependencies**
  2. **Audit: Secret Scanning**
  3. Lint: Dockerfile
  4. Lint: GitHub Actions
  5. Lint: PHP CodeSniffer
  6. Lint: PHP Psalm
  7. Lint: PHPStan
  8. Lint: ShellCheck

### \`test.yml\` — gated on lint success

- Trigger changed from \`pull_request\` to \`workflow_run\` on "Lint & Security" completed — tests only start if linting passed
- Passes \`head_sha\` as \`ref\` to the shared workflow so checkout targets the PR commit, not the base branch (the classic \`workflow_run\` footgun)

### Shared workflow (\`rtldev-middleware-shareable-workflows\`)

- \`lint\` job removed — ownership fully transferred to each SDK repo's \`lint.yml\`
- \`ref\` workflow_call input added; passed to all checkout steps to support \`workflow_run\` callers
- Renamed from "Linting & Coverage" to "Coverage & Tests"
- Committed directly to \`main\`: [e553c83](https://github.com/centralnicgroup-opensource/rtldev-middleware-shareable-workflows/commit/e553c83036704b52db69c035ac30e51a0d231f10)

### \`CLAUDE.md\`

- Documents \`composer audit\` under "Running Tests" so developers can run it locally

## Test plan

- [x] Verify the **Audit: PHP Dependencies** and **Audit: Secret Scanning** jobs appear first in the CI checks list
- [x] Confirm \`composer audit --no-dev\` passes on a clean \`composer.lock\`
- [x] Confirm \`phpcs\`, \`phpstan\`, \`psalm\` each appear as individual checks
- [x] Open or update a PR and verify \`test.yml\` only triggers after \`lint.yml\` completes successfully
- [x] Confirm the shared workflow checkouts target the PR head commit, not \`master\`

Resolves: [RSRMID-2804](https://centralnic.atlassian.net/browse/RSRMID-2804)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RSRMID-2804]: https://centralnic.atlassian.net/browse/RSRMID-2804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ