### PR TITLE
ci(lint): add native ci-success job to guarantee workflow_run fires

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,3 +13,15 @@ jobs:
   lint:
     uses: centralnicgroup-opensource/rtldev-middleware-shareable-workflows/.github/workflows/php-sdk-lint.yml@main
     secrets: inherit
+
+  ci-success:
+    name: "Lint: completed"
+    needs: lint
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check result
+        run: |
+          if [ "${{ needs.lint.result }}" != "success" ]; then
+            exit 1
+          fi


### PR DESCRIPTION
## Problem

GitHub does not emit a `workflow_run` event for a workflow whose only job is a `workflow_call` that never resolves (e.g. the referenced reusable workflow doesn't exist yet, or fails at dispatch time before any jobs start). With the current thin-caller `lint.yml`, the `Lint & Security` run at 07:51 produced **zero** `workflow_run` events — confirmed by a 31-minute gap in `Dependabot auto-merge & tests` runs where one should have appeared.

## Fix

Adds a native `ci-success` job (a simple bash check) that runs after `lint` on every execution. This guarantees the `Lint & Security` workflow always reaches a **completed** state with a runner-backed job, which GitHub's `workflow_run` machinery reliably observes.

Behaviour is unchanged from the user's perspective:
- Lint passes → `ci-success` exits 0 → `workflow_run` fires with `success` → tests start
- Lint fails → `ci-success` exits 1 → `workflow_run` fires with `failure` → tests skipped

## Related

RSRMID-2816 / PR #86 (shareable `php-sdk-lint.yml`) / PR #180 (thin-caller `lint.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)