### PR TITLE
ci(test): switch to pull_request trigger

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,9 @@
 name: Dependabot auto-merge & tests
 "on":
-  workflow_run:
-    workflows:
-      - Lint & Security
+  pull_request:
     types:
-      - completed
+      - opened
+      - synchronize
 
 permissions:
   contents: write
@@ -12,10 +11,7 @@ permissions:
 
 jobs:
   tests:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: centralnicgroup-opensource/rtldev-middleware-shareable-workflows/.github/workflows/php-sdk-test.yml@main
-    with:
-      ref: ${{ github.event.workflow_run.head_sha }}
     secrets: inherit
 
   ci-success:


### PR DESCRIPTION
## Problem

`workflow_run` triggered workflows always report their status checks against the **default branch HEAD**, not the triggering PR's HEAD SHA. This was confirmed empirically: the `Dependabot auto-merge & tests` run at 13:52 was associated with `6105b98` (master HEAD), not `851d2d9` (PR HEAD). As a result, `ci-success` from the test workflow is never visible as a PR status check — test results are invisible on PRs.

## Fix

Switches `test.yml` from `workflow_run` to `pull_request` trigger. Tests now run in parallel with lint. PRs are blocked if either fails, giving equivalent gate behaviour.

The `workflow_run`-specific fields — `if: conclusion == 'success'` on the `tests` job and `ref: ${{ github.event.workflow_run.head_sha }}` — are removed since they're no longer applicable. `php-sdk-test.yml` already defaults `ref` to `""` (standard checkout) when not provided.

## Context

Part of RSRMID-2816 follow-up. See also PR #182 (`lint.yml` `ci-success` relay job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)