### PR TITLE
docs(ci): document why daily-node-refresh replaces Dependabot npm

### DIFF
--- a/.github/workflows/daily-node-dependency-refresh.yml
+++ b/.github/workflows/daily-node-dependency-refresh.yml
@@ -1,4 +1,20 @@
 name: Daily Node dependency refresh
+# Why this workflow exists instead of a Dependabot npm entry:
+#
+# Dependabot version updates only touch direct dependencies, leaving transitive
+# deps untouched. This regularly causes false-positive vulnerability alerts for
+# package-lock.json entries that Dependabot itself cannot resolve.
+#
+# This workflow runs `npm update` across the full dependency tree every day,
+# keeping package-lock.json completely current including transitive packages.
+#
+# Trade-off: there is no immediate Dependabot security PR when a CVE drops for
+# a transitive npm package — the fix arrives on the next daily run (~24 h).
+# This is a deliberate choice to avoid the duplicate-PR and false-positive noise
+# that adding an npm ecosystem to dependabot.yml would reintroduce.
+#
+# Dependabot security alerts (GitHub Advisory Database scanning) remain active
+# independently of dependabot.yml and are not affected by this decision.
 
 on:
   schedule:


### PR DESCRIPTION
## Summary

- Adds an inline comment block to `daily-node-dependency-refresh.yml` explaining why the `npm` ecosystem is intentionally absent from `dependabot.yml`
- Documents the known Dependabot limitation (direct deps only) and the resulting false-positive vulnerability alerts for transitive packages
- Acknowledges the ~24 h trade-off for transitive CVE fixes and confirms that GitHub security alerts remain active independently

## Jira

[RSRMID-2806](https://centralnic.atlassian.net/browse/RSRMID-2806)

## Test plan

- [x] Review the comment block in `.github/workflows/daily-node-dependency-refresh.yml` for accuracy and completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RSRMID-2806]: https://centralnic.atlassian.net/browse/RSRMID-2806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ