### PR TITLE
docs(security): add SECURITY.md for vulnerability disclosure policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest major release receives security fixes. Older major versions are not actively patched.
+
+| Version | Supported |
+| ------- | --------- |
+| 15.x    | ✅        |
+| < 15    | ❌        |
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Use [GitHub Private Vulnerability Reporting](https://github.com/centralnicgroup-opensource/rtldev-middleware-php-sdk/security/advisories/new) to submit a report confidentially. This keeps the details private until a fix is available and integrates directly with GitHub's security advisory workflow.
+
+Include as much of the following as possible:
+
+- A description of the vulnerability and its potential impact
+- Step-by-step reproduction instructions or a proof-of-concept
+- Affected versions
+- Any suggested mitigations
+
+## Response Timeline
+
+| Milestone                                | Target                 |
+| ---------------------------------------- | ---------------------- |
+| Acknowledgement                          | Within 5 business days |
+| Fix or mitigation plan (critical / high) | Within 30 days         |
+| Fix or mitigation plan (medium / low)    | Within 90 days         |
+
+We will keep you informed of progress throughout the process.
+
+## Disclosure Policy
+
+We follow **coordinated disclosure**:
+
+1. The vulnerability is confirmed and a fix is developed in private.
+2. A patched release is published.
+3. The GitHub security advisory is made public after the release.
+
+Reporters are credited in the published advisory unless they prefer to remain anonymous. Please let us know your preference when submitting.


### PR DESCRIPTION
## Summary

- Creates `.github/SECURITY.md` so GitHub surfaces it automatically in the Security tab
- Covers supported versions (v15.x only), GitHub Private Vulnerability Reporting as the contact channel, response SLAs (5 business days to acknowledge; 30 days for critical/high, 90 days for medium/low), and coordinated disclosure policy

## Test plan

- [x] Open the repository Security tab on GitHub and confirm the policy is linked
- [ ] Verify the "Report a vulnerability" button points to the private advisory form

Resolves [RSRMID-2809](https://centralnic.atlassian.net/browse/RSRMID-2809)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RSRMID-2809]: https://centralnic.atlassian.net/browse/RSRMID-2809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ