### PR TITLE
docs(env): add env.example.sh; ci(test): skip matrix on non-test changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,26 @@ permissions:
   pull-requests: write
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'src/**'
+              - 'tests/**'
+              - 'phpunit.xml'
+              - 'composer.json'
+              - 'composer.lock'
+
   tests:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     uses: centralnicgroup-opensource/rtldev-middleware-shareable-workflows/.github/workflows/php-sdk-test.yml@main
     secrets: inherit
 
@@ -20,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          if [ "${{ needs.tests.result }}" != "success" ]; then
+          if [ "${{ needs.tests.result }}" != "success" ] && [ "${{ needs.tests.result }}" != "skipped" ]; then
             echo "Tests failed or were cancelled"
             exit 1
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,14 +81,15 @@ composer audit         # Check dependencies for known CVEs (Composer 2.4+)
 
 ## Important Files
 
-| Path                           | Purpose                            |
-| ------------------------------ | ---------------------------------- |
-| `src/CNR/config.json`          | CNR API endpoints and settings     |
-| `src/IBS/config.json`          | IBS API endpoints and settings     |
-| `src/MONIKER/config.json`      | Moniker API endpoints and settings |
-| `.github/linters/phpcs.xml`    | CodeSniffer PSR-12 config          |
-| `.github/linters/phpstan.neon` | PHPStan level 8 config             |
-| `phpunit.xml`                  | PHPUnit configuration              |
+| Path                           | Purpose                                                |
+| ------------------------------ | ------------------------------------------------------ |
+| `src/CNR/config.json`          | CNR API endpoints and settings                         |
+| `src/IBS/config.json`          | IBS API endpoints and settings                         |
+| `src/MONIKER/config.json`      | Moniker API endpoints and settings                     |
+| `.github/linters/phpcs.xml`    | CodeSniffer PSR-12 config                              |
+| `.github/linters/phpstan.neon` | PHPStan level 8 config                                 |
+| `phpunit.xml`                  | PHPUnit configuration                                  |
+| `env.example.sh`               | Template for required env variables (copy to `env.sh`) |
 
 ## Atlassian / JIRA
 

--- a/README.md
+++ b/README.md
@@ -40,18 +40,7 @@ The devcontainer looks for an `env.sh` file in the workspace root and **automati
 1. **Every new integrated-terminal session** — the file is sourced via `~/.zshenv` so credentials are available as soon as you open a terminal, without a manual `source env.sh`.
 2. **PHPUnit runs triggered from the VSCode UI** — the PHPUnit wrapper script sources `env.sh` before invoking PHP, so IDE-triggered tests see the same variables as `composer test` does from the terminal.
 
-`env.sh` is listed in `.gitignore` and will never be committed. Create it once in the workspace root with the variables you need, for example:
-
-```sh
-export RTLDEV_MW_CI_USER_CNR=<your-username>
-export RTLDEV_MW_CI_USERPASSWORD_CNR=<your-password>
-export RTLDEV_MW_CI_ROLE_CNR=<your-user-role-name>
-export RTLDEV_MW_CI_ROLEPASSWORD_CNR=<your-user-role-password>
-export RTLDEV_MW_CI_USER_IBS=<your-username>
-export RTLDEV_MW_CI_USERPASSWORD_IBS=<your-password>
-export RTLDEV_MW_CI_USER_MONIKER=<your-username>
-export RTLDEV_MW_CI_USERPASSWORD_MONIKER=<your-password>
-```
+`env.sh` is listed in `.gitignore` and will never be committed. Create it once in the workspace root with the variables you need — copy [`env.example.sh`](env.example.sh) as a starting point.
 
 > [!NOTE]
 > The auto-loading takes effect for **new** terminal sessions. If your terminal was already open when you created or updated `env.sh`, run `source env.sh` once in that session or open a new terminal.

--- a/env.example.sh
+++ b/env.example.sh
@@ -1,14 +1,15 @@
+#!/usr/bin/env sh
 # CentralNic Reseller (CNR) credentials
-export RTLDEV_MW_CI_USER_CNR=<your-username>
-export RTLDEV_MW_CI_USERPASSWORD_CNR=<your-password>
+export RTLDEV_MW_CI_USER_CNR="<your-username>"
+export RTLDEV_MW_CI_USERPASSWORD_CNR="<your-password>"
 # Role credentials — required for role-based access tests
-export RTLDEV_MW_CI_ROLE_CNR=<your-role-name>
-export RTLDEV_MW_CI_ROLEPASSWORD_CNR=<your-role-password>
+export RTLDEV_MW_CI_ROLE_CNR="<your-role-name>"
+export RTLDEV_MW_CI_ROLEPASSWORD_CNR="<your-role-password>"
 
 # Internet.bs (IBS) credentials
-export RTLDEV_MW_CI_USER_IBS=<your-username>
-export RTLDEV_MW_CI_USERPASSWORD_IBS=<your-password>
+export RTLDEV_MW_CI_USER_IBS="<your-username>"
+export RTLDEV_MW_CI_USERPASSWORD_IBS="<your-password>"
 
 # Moniker credentials
-export RTLDEV_MW_CI_USER_MONIKER=<your-username>
-export RTLDEV_MW_CI_USERPASSWORD_MONIKER=<your-password>
+export RTLDEV_MW_CI_USER_MONIKER="<your-username>"
+export RTLDEV_MW_CI_USERPASSWORD_MONIKER="<your-password>"

--- a/env.example.sh
+++ b/env.example.sh
@@ -1,0 +1,14 @@
+# CentralNic Reseller (CNR) credentials
+export RTLDEV_MW_CI_USER_CNR=<your-username>
+export RTLDEV_MW_CI_USERPASSWORD_CNR=<your-password>
+# Role credentials — required for role-based access tests
+export RTLDEV_MW_CI_ROLE_CNR=<your-role-name>
+export RTLDEV_MW_CI_ROLEPASSWORD_CNR=<your-role-password>
+
+# Internet.bs (IBS) credentials
+export RTLDEV_MW_CI_USER_IBS=<your-username>
+export RTLDEV_MW_CI_USERPASSWORD_IBS=<your-password>
+
+# Moniker credentials
+export RTLDEV_MW_CI_USER_MONIKER=<your-username>
+export RTLDEV_MW_CI_USERPASSWORD_MONIKER=<your-password>


### PR DESCRIPTION
**Jira:** [RSRMID-2811](https://centralnic.atlassian.net/browse/RSRMID-2811) · [RSRMID-2819](https://centralnic.atlassian.net/browse/RSRMID-2819)

## Summary

- Adds `env.example.sh` to the project root listing all required environment variables with inline comments — covers CNR (including role credentials), IBS, and Moniker
- Replaces the inline code block in `README.md`'s *Environment variables* section with a direct link to the new file, eliminating duplication
- Adds `env.example.sh` to the *Important Files* table in `CLAUDE.md` so contributors know it exists as a setup template
- Adds a `changes` pre-job to the test workflow using `dorny/paths-filter`; gates the PHPUnit matrix with `if: needs.changes.outputs.relevant == 'true'` so it is skipped when only unrelated files (docs, CI config, etc.) are touched — branch protection never blocks because `ci-success` now accepts both `success` and `skipped`

## Test plan

- [x] `env.example.sh` is present in the repo root and committed
- [x] `README.md` no longer duplicates the variable list — it links to `env.example.sh` instead
- [x] Copying `env.example.sh` to `env.sh` and filling in real values allows `composer test` to run
- [x] A PR touching only docs/CI files skips the PHPUnit matrix and the `ci-success` check still passes
- [x] A PR touching `src/` or `tests/` runs the full PHPUnit matrix as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RSRMID-2811]: https://centralnic.atlassian.net/browse/RSRMID-2811
[RSRMID-2819]: https://centralnic.atlassian.net/browse/RSRMID-2819