### PR TITLE
feat(ci): add env.example.sh and integrate Codecov coverage reporting

### DIFF
--- a/.github/phpunit.xml
+++ b/.github/phpunit.xml
@@ -30,6 +30,7 @@
     <coverage>
         <report>
             <html outputDirectory="../reports/html" lowUpperBound="50" highLowerBound="80"/>
+            <clover outputFile="../reports/clover/coverage.xml"/>
             <text outputFile="php://stdout" showUncoveredFiles="false"/>
         </report>
     </coverage>

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![PHP from Packagist](https://img.shields.io/packagist/php-v/centralnic-reseller/php-sdk.svg)](https://packagist.org/packages/centralnic-reseller/php-sdk)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/centralnicgroup-opensource/rtldev-middleware-php-sdk/blob/master/CONTRIBUTING.md)
+[![codecov](https://codecov.io/gh/centralnicgroup-opensource/rtldev-middleware-php-sdk/graph/badge.svg)](https://codecov.io/gh/centralnicgroup-opensource/rtldev-middleware-php-sdk)
 
 This module is a connector library for the insanely fast CNIC Backend APIs (CentralNic Reseller, internet.bs, moniker). Do not hesitate to contact us in case of questions.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+        threshold: 1%


### PR DESCRIPTION
## Summary

- **RSRMID-2811** — Add `env.example.sh` as a template for required environment variables; link it from `README.md` and `CLAUDE.md`; skip PHPUnit matrix in CI when no test-relevant files changed
- **RSRMID-2805** — Integrate Codecov: add Clover XML output to `phpunit.xml`, upload step to the shared `php-sdk-test` workflow (first matrix job only), 80 % threshold gate in `codecov.yml`, and Codecov badge in `README.md`

Jira: [RSRMID-2811](https://centralnic.atlassian.net/browse/RSRMID-2811) | [RSRMID-2805](https://centralnic.atlassian.net/browse/RSRMID-2805)

## Test plan

- [ ] CI passes on this PR (PHPUnit matrix, lint)
- [ ] Coverage report appears on [Codecov dashboard](https://codecov.io/gh/centralnicgroup-opensource/rtldev-middleware-php-sdk) after first CI run
- [ ] Codecov PR comment shows coverage delta
- [ ] Badge renders correctly in `README.md`
- [ ] `env.example.sh` is present and `shellcheck`-clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RSRMID-2811]: https://centralnic.atlassian.net/browse/RSRMID-2811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RSRMID-2805]: https://centralnic.atlassian.net/browse/RSRMID-2805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ