### PR TITLE
feat(ibs): formally implement interfaces and update CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,12 @@ This is the **PHP SDK** for Team Internet backend APIs (CentralNic Reseller, Int
 - **Namespace root:** `CNIC\` mapped to `src/` (PSR-4)
 - **Inheritance chain:** `CNR\Client` and `IBS\Client` extend `CNIC\AbstractClient` directly. `MONIKER\Client` extends `IBS\Client` — Moniker and IBS share the same API platform; only their `config.json` (endpoints/credentials) differs. `CNR\SessionClient` uses the `SessionCapable` trait for login/logout; `IBS\SessionClient` and `MONIKER\SessionClient` are session-less.
 - **Config-driven:** Each sub-namespace has a `config.json` with API URLs, parameter mappings, and feature flags
-- **Interfaces:** `ColumnInterface`, `RecordInterface`, `ResponseInterface`, `LoggerInterface` define contracts; all concrete classes formally declare `implements`
+- **Interfaces:** `ColumnInterface`, `RecordInterface`, `ResponseInterface`, `LoggerInterface` (all in `CNIC\`) define contracts. All concrete classes formally declare `implements`:
+  - `CNR\Column`, `IBS\Column` → `ColumnInterface`
+  - `CNR\Record`, `IBS\Record` → `RecordInterface`
+  - `CNR\Response`, `IBS\Response` → `ResponseInterface`
+  - `CNR\Logger`, `IBS\Logger` → `LoggerInterface`
+  - Type-hint against the interface rather than the concrete class (e.g. `LoggerInterface` not `Logger`, `ResponseInterface` not `Response`)
 - **Factory pattern:** `ClientFactory::getClient()` for instantiation
 
 ## Coding Standards

--- a/src/IBS/Column.php
+++ b/src/IBS/Column.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace CNIC\IBS;
 
 use CNIC\CNR\Column as CNRColumn;
+use CNIC\ColumnInterface;
 
 /**
  * IBS Column
@@ -17,6 +18,6 @@ use CNIC\CNR\Column as CNRColumn;
  * @psalm-api
  * @package CNIC\IBS
  */
-class Column extends CNRColumn
+class Column extends CNRColumn implements ColumnInterface
 {
 }

--- a/src/IBS/Record.php
+++ b/src/IBS/Record.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace CNIC\IBS;
 
 use CNIC\CNR\Record as CNRRecord;
+use CNIC\RecordInterface;
 
 /**
  * IBS Record
@@ -17,6 +18,6 @@ use CNIC\CNR\Record as CNRRecord;
  * @psalm-api
  * @package CNIC\IBS
  */
-class Record extends CNRRecord
+class Record extends CNRRecord implements RecordInterface
 {
 }

--- a/src/IBS/Response.php
+++ b/src/IBS/Response.php
@@ -15,6 +15,7 @@ use CNIC\CNR\Response as CNRResponse;
 use CNIC\CommandFormatter;
 use CNIC\IBS\ResponseParser as RP;
 use CNIC\IBS\ResponseTranslator as RT;
+use CNIC\ResponseInterface;
 
 /**
  * IBS Response
@@ -22,7 +23,7 @@ use CNIC\IBS\ResponseTranslator as RT;
  * @psalm-api
  * @package CNIC\IBS
  */
-class Response extends CNRResponse
+class Response extends CNRResponse implements ResponseInterface
 {
     /**
      * Regex for pagination related column keys


### PR DESCRIPTION
## Summary

- Add explicit `implements ColumnInterface`, `implements RecordInterface`, and `implements ResponseInterface` to `IBS\Column`, `IBS\Record`, and `IBS\Response` respectively — they previously satisfied these contracts only through inheritance from CNR base classes
- Update the Interfaces section of `CLAUDE.md` with a per-class implementation mapping and type-hint guidance

Closes RSRMID-2813

## Test plan

- [x] `composer phpstan` — no errors
- [x] `composer lint` — no errors (one `use` sort violation auto-fixed by `codefix`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)