### PR TITLE
feat(ci): add monthly Rector modernization workflow

### DIFF
--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -1,0 +1,47 @@
+name: Monthly Rector modernization
+
+on:
+  schedule:
+    - cron: "0 8 1 * *" # First of each month at 08:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: rector-modernization
+  cancel-in-progress: false
+
+jobs:
+  rector:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Run Rector
+        run: composer rector:fix
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore(rector): apply automated modernization fixes"
+          branch: chore/rector-modernization
+          delete-branch: true
+          title: "chore(rector): apply automated modernization fixes"
+          body: |
+            Automated Rector run applying PHP 8.3 modernization fixes.
+
+            **Rulesets applied:** `CODE_QUALITY`, `DEAD_CODE`, `PHP_83`
+
+            Triggered by: ${{ github.event_name }}
+          base: master

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,14 @@ composer phpstan       # Static analysis
 composer audit         # Check dependencies for known CVEs (Composer 2.4+)
 ```
 
+## Codebase Modernization (Rector)
+
+Rector is configured in `.github/linters/rector.php` targeting PHP 8.3 with `CODE_QUALITY`, `DEAD_CODE`, and `PHP_83` rulesets.
+
+- **CI (lint workflow):** runs in dry-run mode (`composer rector`) — detects issues only, never writes.
+- **Automated apply:** `.github/workflows/rector.yml` runs `composer rector:fix` on the first of each month and opens a PR (`chore/rector-modernization`) with commit message `chore(rector): apply automated modernization fixes`. Can also be triggered manually via `workflow_dispatch`.
+- **Manual apply:** run `composer rector:fix` locally and open a PR with the same commit prefix.
+
 ## Git Conventions
 
 - **Commit messages:** Conventional Commits (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/rector.yml` triggered on the 1st of each month at 08:00 UTC and via `workflow_dispatch`
- Runs `composer rector:fix` (PHP 8.3, `CODE_QUALITY` / `DEAD_CODE` / `PHP_83` rulesets) and opens a PR with `chore(rector): apply automated modernization fixes` if changes are found
- Documents the automated and manual Rector process in `CLAUDE.md`

Closes [RSRMID-2808](https://centralnic.atlassian.net/browse/RSRMID-2808)

## Test plan

- [ ] Trigger `Monthly Rector modernization` via `workflow_dispatch` and confirm it completes (or skips PR creation if no changes)
- [ ] Verify the generated PR (if any) carries the correct commit message and targets `master`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RSRMID-2808]: https://centralnic.atlassian.net/browse/RSRMID-2808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ