### PR TITLE
fix(ci): correct devcontainer node feature tag, paths-filter path, and reopened trigger

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -10,10 +10,10 @@
       "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
       "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
     },
-    "ghcr.io/devcontainers/features/node:": {
-      "version": "2.1.0",
-      "resolved": "ghcr.io/devcontainers/features/node@sha256:586c9a6f7dd40bd3ba2cd41e7f2f88dcc31fbe5d1442afcbf07ffbc66b686857",
-      "integrity": "sha256:586c9a6f7dd40bd3ba2cd41e7f2f88dcc31fbe5d1442afcbf07ffbc66b686857"
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
     },
     "ghcr.io/devcontainers/features/php:1": {
       "version": "1.1.5",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -49,7 +49,7 @@
       "installComposer": true,
       "extensions": "xdebug"
     },
-    "ghcr.io/devcontainers/features/node:": {
+    "ghcr.io/devcontainers/features/node:1": {
       "version": "lts"
     },
     "ghcr.io/devcontainers/features/github-cli:1": {},

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,7 @@ name: Lint & Security
     types:
       - opened
       - synchronize
+      - reopened
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ name: Dependabot auto-merge & tests
     types:
       - opened
       - synchronize
+      - reopened
 
 permissions:
   contents: write
@@ -23,7 +24,7 @@ jobs:
             relevant:
               - 'src/**'
               - 'tests/**'
-              - 'phpunit.xml'
+              - '.github/phpunit.xml'
               - 'composer.json'
               - 'composer.lock'
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,15 @@ Rector is configured in `.github/linters/rector.php` targeting PHP 8.3 with `COD
 ## Git Conventions
 
 - **Commit messages:** Angular/Conventional Commits with **mandatory scope**: `<type>(<scope>): <summary>` — e.g. `fix(psalm): resolve static analysis warnings`, `feat(ibs): add response translation`. Never append a `Co-Authored-By:` trailer.
+- **Commit type selection:** `fix` and `feat` are reserved for changes to library source code in `src/` — they trigger a release. For everything else use a non-releasing type: `ci` for CI workflows and devcontainer, `build` for build tooling or scripts, `chore` for housekeeping, `docs` for documentation, `test` for test-only changes, `refactor` for internal restructuring without behaviour change.
+- **Breaking changes:** When a `src/` change breaks the public API, add a `BREAKING CHANGE: <short summary>` line to the commit message body (blank line after the subject). This triggers a **major** version bump via semantic-release. Example:
+
+  ```
+  feat(client): remove deprecated setProxy() method
+
+  BREAKING CHANGE: setProxy() has been removed; use HttpTransport::withProxy() instead.
+  ```
+
 - **Branch naming:** prefix with the Jira issue ID — e.g. `RSRMID-2821/short-description`
 - **Pull requests:** always include the Jira issue link in the PR description. After opening the PR, add the PR URL as a comment on the Jira issue.
 - **Default branch:** `master`


### PR DESCRIPTION
## Summary

- **Devcontainer:** Fix malformed Node feature ID `ghcr.io/devcontainers/features/node:` (trailing colon, empty tag) → `ghcr.io/devcontainers/features/node:1`
- **CI paths-filter:** `test.yml` watched `phpunit.xml` at repo root; actual config is `.github/phpunit.xml`, so edits to it never triggered the test workflow
- **CI triggers:** Add `reopened` event to `lint.yml` and `test.yml` so CI re-runs when a closed PR is reopened

Resolves [RSRMID-2825](https://centralnic.atlassian.net/browse/RSRMID-2825)

## Test plan

- [ ] Rebuild the devcontainer and confirm Node installs without error
- [ ] Modify `.github/phpunit.xml` in a PR branch and confirm the test workflow is triggered
- [ ] Close and reopen a PR and confirm lint and test workflows start automatically

[RSRMID-2825]: https://centralnic.atlassian.net/browse/RSRMID-2825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ