### PR TITLE
docs(whmcs): document PHP version ceiling and add monthly WHMCS check

### DIFF
--- a/.github/linters/rector.php
+++ b/.github/linters/rector.php
@@ -3,14 +3,15 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\ValueObject\PhpVersion;
 use Rector\Set\ValueObject\SetList;
+use Rector\ValueObject\PhpVersion;
 
 return RectorConfig::configure()
     ->withPaths([
         __DIR__ . '/../../src',
         __DIR__ . '/../../tests',
     ])
+    // Pinned to 8.3: ceiling is set by WHMCS compatibility (see RSRMID-2826).
     ->withPhpVersion(PhpVersion::PHP_83)
     ->withSets([
         SetList::CODE_QUALITY,

--- a/.github/workflows/whmcs-php-check.yml
+++ b/.github/workflows/whmcs-php-check.yml
@@ -1,0 +1,12 @@
+name: Monthly WHMCS PHP version check
+
+on:
+  schedule:
+    - cron: "0 6 1 * *" # First of each month at 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  check:
+    uses: centralnicgroup-opensource/rtldev-middleware-shareable-workflows/.github/workflows/whmcs-php-check.yml@main
+    with:
+      pinned-php-version: "8.3"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,17 @@ Rector is configured in `.github/linters/rector.php` targeting PHP 8.3 with `COD
 - **Automated apply:** `.github/workflows/rector.yml` runs `composer rector:fix` on the first of each month and opens a PR (`chore/rector-modernization`) with commit message `chore(rector): apply automated modernization fixes`. Can also be triggered manually via `workflow_dispatch`.
 - **Manual apply:** run `composer rector:fix` locally and open a PR with the same commit prefix.
 
+## PHP Version Policy
+
+The SDK targets **PHP 8.3** as both its minimum and maximum supported version. This is not arbitrary — the SDK is deployed inside WHMCS environments and must align with what WHMCS itself supports:
+
+- **WHMCS 9 (GA)** — minimum supported PHP: 8.3
+- **WHMCS 8.13 (LTS)** — maximum supported PHP: 8.3
+
+PHP 8.3 is therefore the correct ceiling: it is simultaneously the floor of the current GA release and the ceiling of the current LTS release.
+
+Do **not** bump `composer.json`, `rector.php`, or CI matrix entries beyond PHP 8.3 until WHMCS raises its own minimum supported PHP version. Track [RSRMID-2826](https://centralnic.atlassian.net/browse/RSRMID-2826) for the unblocking condition.
+
 ## Git Conventions
 
 - **Commit messages:** Angular/Conventional Commits with **mandatory scope**: `<type>(<scope>): <summary>` — e.g. `fix(psalm): resolve static analysis warnings`, `feat(ibs): add response translation`. Never append a `Co-Authored-By:` trailer.


### PR DESCRIPTION
## Summary

- Adds a **PHP Version Policy** section to `CLAUDE.md` documenting why PHP 8.3 is the ceiling: the SDK runs inside WHMCS environments, and 8.3 is simultaneously the floor of WHMCS 9 (GA) and the ceiling of WHMCS 8.13 (LTS).
- Adds an inline comment in `.github/linters/rector.php` above `withPhpVersion(PhpVersion::PHP_83)` pointing to RSRMID-2826.
- Adds `.github/workflows/whmcs-php-check.yml` — a monthly scheduled workflow that calls the reusable `whmcs-php-check` workflow in `rtldev-middleware-shareable-workflows` (PR pending there) to automatically detect if the WHMCS-supported PHP ceiling changes.

## How the check works

1. POSTs to `https://download.whmcs.com/assets/scripts/get-downloads.php` — returns clean JSON with the current GA and LTS major versions (no auth required).
2. Fetches the system requirements docs page for each version and greps for `PHP X.Y` mentions.
3. Fails if `lts_max_php > 8.3` or `ga_min_php > 8.3`, or if the docs page can't be parsed (manual check required).
4. Succeeds silently if PHP 8.3 is still the correct version.

Relates to: https://centralnic.atlassian.net/browse/RSRMID-2826