### PR TITLE
chore(repo): prune stale npm-to-pnpm config leftovers and document lockfile policy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,9 +12,7 @@ build export-ignore
 # files to exclude
 .releaserc.json export-ignore
 package.json export-ignore
-package-lock.json export-ignore
-phpdoc.dist.xml export-ignore
-phpunit.xml.dist export-ignore
+pnpm-lock.yaml export-ignore
 *.sh export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ build/api-cache
 php-sdk.phar
 php-sdk.phar.gz
 reports
-package-lock.json
 .pnpm-store
 # do not remove the following line
 # it blocks env.sh from being committed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,11 @@ PHP 8.3 is therefore the correct ceiling: it is simultaneously the floor of the 
 
 Do **not** bump `composer.json`, `rector.php`, or CI matrix entries beyond PHP 8.3 until WHMCS raises its own minimum supported PHP version. Track [RSRMID-2826](https://centralnic.atlassian.net/browse/RSRMID-2826) for the unblocking condition.
 
+## Dependency Lockfile Policy
+
+- **`composer.lock` is committed deliberately.** Conventional guidance says a library should not commit its lockfile because consumers ignore it (Composer resolves the library's constraints fresh into the consumer's own `composer.lock`). That still holds for consumers — keeping our lockfile does **not** affect downstream installs. We commit it anyway so that CI, devcontainer, and local developer setups all resolve the exact same dependency tree, giving reproducible lint/test runs and pinning the dev toolchain (PHPUnit, PHPStan, Psalm, Rector). Do not remove or git-ignore `composer.lock`.
+- **`pnpm-lock.yaml` is committed** (the project migrated from npm to pnpm; the old `package-lock.json` is gone). Both lockfiles are `export-ignore`d in `.gitattributes` so they stay out of the Composer distribution archive.
+
 ## Git Conventions
 
 - **Commit messages:** Angular/Conventional Commits with **mandatory scope**: `<type>(<scope>): <summary>` — e.g. `fix(psalm): resolve static analysis warnings`, `feat(ibs): add response translation`. Never append a `Co-Authored-By:` trailer.


### PR DESCRIPTION
## Summary

Repository housekeeping from [RSRMID-2828](https://centralnic.atlassian.net/browse/RSRMID-2828).

- **`.gitattributes`** — removed dead `export-ignore` entries for files that no longer exist (`phpdoc.dist.xml`, `phpunit.xml.dist`, `package-lock.json`) and `export-ignore` the current `pnpm-lock.yaml` instead, so the live lockfile stays out of the Composer distribution archive.
- **`.gitignore`** — removed the leftover `package-lock.json` ignore (project migrated from npm to pnpm and commits `pnpm-lock.yaml`).
- **`composer.lock` policy** — decided **deliberately to keep it committed** and documented the rationale in a new *Dependency Lockfile Policy* section in `CLAUDE.md` (reproducible CI / devcontainer / local runs and pinned dev toolchain; consumers ignore it regardless of whether we commit it).

No `src/` changes — non-releasing (`chore`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RSRMID-2828]: https://centralnic.atlassian.net/browse/RSRMID-2828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ