### PR TITLE
ci(dependabot): add update groups and tune cadence to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,33 +1,72 @@
 version: 2
+
+# NOTE: there is intentionally no "npm" ecosystem here.
+# Node dependencies are refreshed by .github/workflows/daily-node-dependency-refresh.yml
+# (full `npm update` incl. transitive deps) to avoid the duplicate-PR / false-positive
+# noise a Dependabot npm entry would reintroduce. Do not add an npm ecosystem.
+#
+# Cadence is weekly across the board: `schedule` controls *version* updates only —
+# security updates are raised independently of this schedule, so weekly loses no CVE
+# responsiveness while collapsing routine bumps into one predictable batch.
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
     commit-message:
       prefix: "chore"
       include: "scope"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
     commit-message:
       prefix: "chore"
       include: "scope"
+    groups:
+      devcontainers:
+        patterns:
+          - "*"
 
   - package-ecosystem: "docker"
     directory: "/.devcontainer"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
     commit-message:
       prefix: "chore"
       include: "scope"
+    groups:
+      docker:
+        patterns:
+          - "*"
 
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
     commit-message:
       prefix: "chore"
       include: "scope"
+    groups:
+      composer-production:
+        dependency-type: "production"
+        patterns:
+          - "*"
+      composer-development:
+        dependency-type: "development"
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Cuts Dependabot PR noise by grouping updates per ecosystem and relaxing the routine cadence to weekly.

Jira: [RSRMID-2829](https://centralnic.atlassian.net/browse/RSRMID-2829)

## Changes

- **Grouping** — routine bumps now land in a single PR per ecosystem instead of one PR per dependency:
  - `github-actions`, `docker`, `devcontainers`: one group each (`patterns: ["*"]`)
  - `composer`: split into `production` and `development` groups so the rare production dependency change stays reviewable while the dev toolchain (PHPUnit, PHPStan, Psalm, Rector, phpcs, slevomat) batches together
- **Cadence** — `github-actions`, `docker` and `composer` moved from **daily → weekly** (monday). `schedule` governs *version* updates only; **security updates are raised independently**, so weekly loses no CVE responsiveness while collapsing routine bumps into one predictable batch. `devcontainers` was already weekly.
- **`open-pull-requests-limit: 5`** added per ecosystem as an explicit ceiling.
- **Documented the deliberate npm omission** in a header comment pointing to `daily-node-dependency-refresh.yml`, so the gap isn't "fixed" by a future contributor.

## Notes

- Existing `commit-message` config (`prefix: chore`, `include: scope`) preserved.
- No `src/` changes — non-releasing `ci` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RSRMID-2829]: https://centralnic.atlassian.net/browse/RSRMID-2829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ