### PR TITLE
build(uml): pin plantuml.jar version and verify sha256 checksum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ env.sh
 docs/
 
 # uml diagram related
-plantuml.jar
+# (plantuml.jar now lives under tools/, covered below)
 uml.puml
 tools/
 

--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
     "rector": "rector process --config .github/linters/rector.php --dry-run",
     "rector:fix": "rector process --config .github/linters/rector.php",
     "docs:serve": "php -S 0.0.0.0:8000 -t docs",
-    "generate-uml": "test -f tools/php-class-diagram/vendor/bin/php-class-diagram || (mkdir -p tools/php-class-diagram && composer require --working-dir=tools/php-class-diagram smeghead/php-class-diagram:^1.5); test ! -e plantuml.jar && wget https://sourceforge.net/projects/plantuml/files/plantuml.jar/download -O plantuml.jar; tools/php-class-diagram/vendor/bin/php-class-diagram --jig-diagram src/ >> ./docs/uml.puml; java -jar plantuml.jar ./docs/uml.puml -o uml_diagram"
+    "generate-uml": "test -f tools/php-class-diagram/vendor/bin/php-class-diagram || (mkdir -p tools/php-class-diagram && composer require --working-dir=tools/php-class-diagram smeghead/php-class-diagram:^1.5); test -f tools/plantuml.jar || (mkdir -p tools && wget -q https://github.com/plantuml/plantuml/releases/download/v1.2026.6/plantuml-1.2026.6.jar -O tools/plantuml.jar && echo '89948f14c93756c7a3fb7b69078ff37e8489fd79dd430c582b931e2f65358690  tools/plantuml.jar' | sha256sum -c); tools/php-class-diagram/vendor/bin/php-class-diagram --jig-diagram src/ >> ./docs/uml.puml; java -jar tools/plantuml.jar ./docs/uml.puml -o uml_diagram"
   },
   "config": {
     "allow-plugins": {


### PR DESCRIPTION
## Summary

The `generate-uml` composer script downloaded `plantuml.jar` from a generic SourceForge "latest" redirect with **no version pin and no integrity verification**, then executed it via `java -jar`. By contrast, the adjacent `docs` script already verifies the Doctum phar with `sha256sum -c`. This closes that supply-chain gap.

## Changes

- Pin **plantuml 1.2026.6** (from GitHub releases — a stable, versionable URL, unlike the SourceForge always-latest redirect).
- Download to `tools/plantuml.jar` and verify its **sha256** with `sha256sum -c` before use, mirroring the Doctum pattern in the `docs` script.
- sha256 `89948f14c93756c7a3fb7b69078ff37e8489fd79dd430c582b931e2f65358690` — computed locally **and** matches GitHub's official asset digest.
- Prune the now-redundant standalone `plantuml.jar` entry from `.gitignore` (`tools/` already covers it).

## Verification

- Download + `sha256sum -c` runs green; re-run correctly skips re-download (idempotent).
- `composer validate` passes.
- Note: `java` is not present in the devcontainer, so the actual diagram render step was not exercised here; only the download/checksum logic was.

## Scope note

A separate, unrelated correctness bug in the same script (`>> ./docs/uml.puml` should be `>`, which accumulates stale UML across reruns) is intentionally **out of scope** here and handled in a follow-up PR under the same ticket.

Jira: [RSRMID-2830](https://centralnic.atlassian.net/browse/RSRMID-2830)

[RSRMID-2830]: https://centralnic.atlassian.net/browse/RSRMID-2830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ