### PR TITLE
build(uml): truncate uml.puml on regenerate instead of appending

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
     "rector": "rector process --config .github/linters/rector.php --dry-run",
     "rector:fix": "rector process --config .github/linters/rector.php",
     "docs:serve": "php -S 0.0.0.0:8000 -t docs",
-    "generate-uml": "test -f tools/php-class-diagram/vendor/bin/php-class-diagram || (mkdir -p tools/php-class-diagram && composer require --working-dir=tools/php-class-diagram smeghead/php-class-diagram:^1.5); test -f tools/plantuml.jar || (mkdir -p tools && wget -q https://github.com/plantuml/plantuml/releases/download/v1.2026.6/plantuml-1.2026.6.jar -O tools/plantuml.jar && echo '89948f14c93756c7a3fb7b69078ff37e8489fd79dd430c582b931e2f65358690  tools/plantuml.jar' | sha256sum -c); tools/php-class-diagram/vendor/bin/php-class-diagram --jig-diagram src/ >> ./docs/uml.puml; java -jar tools/plantuml.jar ./docs/uml.puml -o uml_diagram"
+    "generate-uml": "test -f tools/php-class-diagram/vendor/bin/php-class-diagram || (mkdir -p tools/php-class-diagram && composer require --working-dir=tools/php-class-diagram smeghead/php-class-diagram:^1.5); test -f tools/plantuml.jar || (mkdir -p tools && wget -q https://github.com/plantuml/plantuml/releases/download/v1.2026.6/plantuml-1.2026.6.jar -O tools/plantuml.jar && echo '89948f14c93756c7a3fb7b69078ff37e8489fd79dd430c582b931e2f65358690  tools/plantuml.jar' | sha256sum -c); tools/php-class-diagram/vendor/bin/php-class-diagram --jig-diagram src/ > ./docs/uml.puml; java -jar tools/plantuml.jar ./docs/uml.puml -o uml_diagram"
   },
   "config": {
     "allow-plugins": {


### PR DESCRIPTION
## Summary

Follow-up to #207, same ticket. While hardening the `generate-uml` script's supply-chain handling, an adjacent **correctness bug** surfaced in the same line: the php-class-diagram output was redirected into `./docs/uml.puml` with `>>` (append).

On every rerun the freshly generated UML source was concatenated onto the previous contents, **stacking duplicate diagram definitions** and producing a malformed render. It has survived only because releases generate docs from a clean checkout where `uml.puml` doesn't yet exist — it bites anyone running `composer generate-uml` twice locally.

## Change

One character: `>>` → `>` so each run truncates and produces a clean, single-diagram file.

## Scope note

Kept separate from #207 so the supply-chain fix and this correctness fix have independent, focused histories. Both are tracked under RSRMID-2830.

⚠️ This branch and #207 edit the same `generate-uml` line. Whichever merges second will need a trivial one-line rebase. Recommend merging #207 first.

Jira: [RSRMID-2830](https://centralnic.atlassian.net/browse/RSRMID-2830)

[RSRMID-2830]: https://centralnic.atlassian.net/browse/RSRMID-2830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ