### PR TITLE
build(deps): remove stale npm/package-lock references after pnpm migration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,9 @@
 version: 2
 
 # NOTE: there is intentionally no "npm" ecosystem here.
+# ("npm" is Dependabot's identifier for the JS ecosystem; it resolves pnpm-lock.yaml too.)
 # Node dependencies are refreshed by .github/workflows/daily-node-dependency-refresh.yml
-# (full `npm update` incl. transitive deps) to avoid the duplicate-PR / false-positive
+# (full `pnpm update` incl. transitive deps) to avoid the duplicate-PR / false-positive
 # noise a Dependabot npm entry would reintroduce. Do not add an npm ecosystem.
 #
 # Cadence is weekly across the board: `schedule` controls *version* updates only —

--- a/.github/workflows/daily-node-dependency-refresh.yml
+++ b/.github/workflows/daily-node-dependency-refresh.yml
@@ -3,13 +3,13 @@ name: Daily Node dependency refresh
 #
 # Dependabot version updates only touch direct dependencies, leaving transitive
 # deps untouched. This regularly causes false-positive vulnerability alerts for
-# package-lock.json entries that Dependabot itself cannot resolve.
+# pnpm-lock.yaml entries that Dependabot itself cannot resolve.
 #
-# This workflow runs `npm update` across the full dependency tree every day,
-# keeping package-lock.json completely current including transitive packages.
+# This workflow runs `pnpm update` across the full dependency tree every day,
+# keeping pnpm-lock.yaml completely current including transitive packages.
 #
 # Trade-off: there is no immediate Dependabot security PR when a CVE drops for
-# a transitive npm package — the fix arrives on the next daily run (~24 h).
+# a transitive Node dependency — the fix arrives on the next daily run (~24 h).
 # This is a deliberate choice to avoid the duplicate-PR and false-positive noise
 # that adding an npm ecosystem to dependabot.yml would reintroduce.
 #

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -34,7 +34,8 @@
       {
         "assets": [
           "HISTORY.md",
-          "@(package?(-lock)|composer).json",
+          "@(package|composer).json",
+          "pnpm-lock.yaml",
           "src/AbstractClient.php"
         ]
       }


### PR DESCRIPTION
## Summary

Cleans up npm/`package-lock.json` leftovers from the pnpm migration.

- **`.github/dependabot.yml`** — reword the "no npm ecosystem" note: `npm update` → `pnpm update`, and clarify that `"npm"` is Dependabot's JS-ecosystem identifier (which resolves `pnpm-lock.yaml`).
- **`.github/workflows/daily-node-dependency-refresh.yml`** — header comment now references `pnpm update` / `pnpm-lock.yaml` (and "transitive npm package" → "transitive Node dependency").
- **`.releaserc.json`** — `@semantic-release/git` assets: drop the dead `package-lock.json` match (`@(package?(-lock)|composer).json` → `@(package|composer).json`) and add `pnpm-lock.yaml` as its own entry so the current lockfile is committed on release.

Comment/config only — non-releasing (`build`).

## Jira

https://centralnic.atlassian.net/browse/RSRMID-2834

🤖 Generated with [Claude Code](https://claude.com/claude-code)