### PR TITLE
docs(audit): document CI composer audit coverage from shared workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,11 @@ permissions:
   pull-requests: write
 
 jobs:
+  # Delegates to the shared php-sdk-lint workflow, which runs these jobs:
+  #   composer-audit (composer audit --no-dev — dependency CVE gating),
+  #   trufflehog, actionlint, hadolint, shellcheck, phpcs, phpstan, psalm.
+  # See: centralnicgroup-opensource/rtldev-middleware-shareable-workflows
+  #      .github/workflows/php-sdk-lint.yml
   lint:
     uses: centralnicgroup-opensource/rtldev-middleware-shareable-workflows/.github/workflows/php-sdk-lint.yml@main
     secrets: inherit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,8 @@ composer rector:fix    # Rector apply (write modernized code)
 composer audit         # Check dependencies for known CVEs (Composer 2.4+)
 ```
 
+> **CI coverage:** `composer audit` is a pre-flight convenience command, not a `composer.json` script. Dependency CVE gating is already enforced on every PR by the shared `php-sdk-lint.yml` workflow (its `composer-audit` job runs `composer audit --no-dev`), which `.github/workflows/lint.yml` delegates to. There is no separate audit step to wire into this repo.
+
 ## Codebase Modernization (Rector)
 
 Rector is configured in `.github/linters/rector.php` targeting PHP 8.3 with `CODE_QUALITY`, `DEAD_CODE`, and `PHP_83` rulesets.


### PR DESCRIPTION
## Summary

RSRMID-2835 asked to "wire composer audit into CI dependency CVE scanning." Investigation found it is **already wired** — the shared [`php-sdk-lint.yml`](https://github.com/centralnicgroup-opensource/rtldev-middleware-shareable-workflows/blob/main/.github/workflows/php-sdk-lint.yml) workflow has a `composer-audit` job running `composer audit --no-dev` on every PR, and our local `.github/workflows/lint.yml` delegates to it.

The ticket arose because that coverage lives in another repo and is invisible from this one, so a reviewer/audit reading this repo in isolation re-derives a "gap." This PR closes that **discoverability gap** rather than adding redundant CI.

## Changes

- **`.github/workflows/lint.yml`** — comment above the `lint:` job listing the shared workflow's jobs (composer-audit, trufflehog, actionlint, hadolint, shellcheck, phpcs, phpstan, psalm).
- **`CLAUDE.md`** — note next to the `composer audit` command clarifying it is a pre-flight convenience command (not a `composer.json` script) and that CVE gating already runs on every PR via the shared workflow.

No `src/` changes — `docs`-type, non-releasing.

## Jira

https://centralnic.atlassian.net/browse/RSRMID-2835

🤖 Generated with [Claude Code](https://claude.com/claude-code)