### PR TITLE
build(uml): guard against stray root plantuml.jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ docs/
 # (plantuml.jar now lives under tools/, covered below)
 uml.puml
 tools/
+# guard against a stray plantuml.jar being re-added at the repo root
+/plantuml.jar
 
 # Claude Code — local user settings (personal overrides, MCP permissions)
 .claude/settings.local.json


### PR DESCRIPTION
## Summary

Adds a root-anchored `.gitignore` guard so a stray `plantuml.jar` can never be re-added at the repo root.

An 11 MB `plantuml.jar` leftover from May 2023 used to sit in the repo root — untracked and not covered by `.gitignore` (only `tools/` and `uml.puml` were ignored). It showed up as git status noise and was one stray `git add .` away from being committed. The UML tooling now downloads PlantUML into `tools/` (already ignored), so the root copy is obsolete.

The stray file is already absent from the working tree and was never tracked, so no deletion was needed. This change just adds the preventive guard:

```gitignore
# guard against a stray plantuml.jar being re-added at the repo root
/plantuml.jar
```

## Verification

`git check-ignore -v plantuml.jar` confirms the root `plantuml.jar` now matches the new rule.

Jira: https://centralnic.atlassian.net/browse/RSRMID-2837

🤖 Generated with [Claude Code](https://claude.com/claude-code)