### PR TITLE
test(ibs): add dedicated ResponseTranslator/ResponseTemplateManager tests

### DIFF
--- a/src/IBS/ResponseTranslator.php
+++ b/src/IBS/ResponseTranslator.php
@@ -18,6 +18,12 @@ use CNIC\IBS\ResponseTemplateManager as RTM;
  */
 final class ResponseTranslator
 {
+    // NOTE: IBS has no brand-specific message rewrites yet, so both maps below are
+    // intentionally empty. While they stay empty, translate() returns via the early
+    // exit in the "$descriptionRegexMap === [] && $descriptionRawPatternMap === []"
+    // branch and findMatch() is never reached — it is kept for structural parity with
+    // CNR\ResponseTranslator and becomes live as soon as an entry is added here.
+
     /**
      * plain-string description keys for translation; keys are preg_quote'd before matching
      * @var array<string, string>

--- a/tests/IBS/ResponseTemplateManagerTest.php
+++ b/tests/IBS/ResponseTemplateManagerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CNICTEST\IBS;
+
+use CNIC\IBS\Response as R;
+use CNIC\IBS\ResponseTemplateManager as RTM;
+use PHPUnit\Framework\TestCase;
+
+final class ResponseTemplateManagerTest extends TestCase
+{
+    public function testGetTemplateNotFound(): void
+    {
+        $tpl = RTM::getTemplate("IwontExist");
+        $this->assertEquals("FAILURE", $tpl->getStatus());
+        $this->assertEquals("500 Response Template not found", $tpl->getDescription());
+    }
+
+    public function testGetTemplates(): void
+    {
+        $tpl = RTM::getTemplates();
+        foreach (array_keys(RTM::$templates) as $key) {
+            $this->assertArrayHasKey($key, $tpl);
+        }
+    }
+
+    public function testGenerateTemplate(): void
+    {
+        $this->assertSame(
+            "status=SUCCESS\r\nmessage=Command completed successfully\r\n",
+            RTM::generateTemplate("SUCCESS", "Command completed successfully")
+        );
+    }
+
+    public function testHasTemplate(): void
+    {
+        $this->assertTrue(RTM::hasTemplate("empty"));
+        $this->assertFalse(RTM::hasTemplate("IwontExist"));
+    }
+
+    public function testIsTemplateMatchHash(): void
+    {
+        $r = new R("");
+        $this->assertTrue(RTM::isTemplateMatchHash($r->getHash(), "empty"));
+
+        // non-matching hash returns false
+        $this->assertFalse(RTM::isTemplateMatchHash(
+            ["status" => "SUCCESS", "message" => "Command completed successfully"],
+            "empty"
+        ));
+    }
+
+    public function testIsTemplateMatchPlain(): void
+    {
+        $r = new R("");
+        $this->assertTrue(RTM::isTemplateMatchPlain($r->getPlain(), "empty"));
+
+        // non-matching plain response returns false
+        $this->assertFalse(RTM::isTemplateMatchPlain(
+            "status=SUCCESS\r\nmessage=Command completed successfully\r\n",
+            "empty"
+        ));
+    }
+
+    public function testAddTemplate(): void
+    {
+        // providing template in plain text
+        $tplid = "custom403";
+        RTM::addTemplate($tplid, "status=FAILURE\r\nmessage=Forbidden\r\n");
+        $this->assertTrue(RTM::hasTemplate($tplid));
+        $tpl = RTM::getTemplate($tplid);
+        $this->assertEquals("FAILURE", $tpl->getStatus());
+        $this->assertEquals("Forbidden", $tpl->getDescription());
+
+        // providing template by status and description
+        $tplid = "custom2_403";
+        RTM::addTemplate($tplid, "FAILURE", "Forbidden");
+        $this->assertTrue(RTM::hasTemplate($tplid));
+        $tpl = RTM::getTemplate($tplid);
+        $this->assertEquals("FAILURE", $tpl->getStatus());
+        $this->assertEquals("Forbidden", $tpl->getDescription());
+    }
+
+    public function testAddTemplateReturnsSelfForChaining(): void
+    {
+        $this->assertInstanceOf(RTM::class, RTM::addTemplate("chainA", "FAILURE", "A"));
+
+        RTM::addTemplate("chainB", "FAILURE", "B")::addTemplate("chainC", "FAILURE", "C");
+        $this->assertTrue(RTM::hasTemplate("chainB"));
+        $this->assertTrue(RTM::hasTemplate("chainC"));
+    }
+}

--- a/tests/IBS/ResponseTest.php
+++ b/tests/IBS/ResponseTest.php
@@ -6,12 +6,12 @@ namespace CNICTEST\IBS;
 
 use CNIC\IBS\Response as R;
 use CNIC\IBS\ResponseParser as RP;
-use CNIC\IBS\ResponseTemplateManager as RTM;
-use CNIC\IBS\ResponseTranslator as RT;
 use PHPUnit\Framework\TestCase;
 
 final class ResponseTest extends TestCase
 {
+    // --- ResponseParser: JSON parsing ---
+
     public function testParseResponseWithDates(): void
     {
         $raw = (string) json_encode([
@@ -85,6 +85,32 @@ final class ResponseTest extends TestCase
         $this->assertSame($expected, RP::parse($raw));
     }
 
+    public function testParseNestedDateNormalization(): void
+    {
+        $raw = (string) json_encode([
+            "domain" => "ibstest.com",
+            "data" => [
+                "expirationdate" => "2026/02/20",
+                "nested" => ["paiduntil" => "2027/01/02"]
+            ]
+        ]);
+        $expected = [
+            "domain" => "ibstest.com",
+            "data" => [
+                "expirationdate" => "2026-02-20",
+                "nested" => ["paiduntil" => "2027-01-02"]
+            ]
+        ];
+        $this->assertSame($expected, RP::parse($raw));
+    }
+
+    public function testParseResponseFormatCaseInsensitive(): void
+    {
+        // a lowercase "json" ResponseFormat is still treated as JSON
+        $result = RP::parse('{"status":"SUCCESS"}', ["ResponseFormat" => "json"]);
+        $this->assertSame(["status" => "SUCCESS"], $result);
+    }
+
     // --- ResponseParser: plain text and invalid ---
 
     public function testParsePlainTextResponse(): void
@@ -103,87 +129,37 @@ final class ResponseTest extends TestCase
         $this->assertSame('423 Invalid API response. Contact Support', $result['message']);
     }
 
-    // --- ResponseTemplateManager tests ---
-
-    public function testGetTemplateNotFound(): void
+    public function testParseEmptyStringIsInvalid(): void
     {
-        $tpl = RTM::getTemplate("IwontExist");
-        $this->assertEquals("FAILURE", $tpl->getStatus());
-        $this->assertEquals("500 Response Template not found", $tpl->getDescription());
+        $result = RP::parse("");
+        $this->assertSame('FAILURE', $result['status']);
+        $this->assertSame('423 Invalid API response. Contact Support', $result['message']);
     }
 
-    public function testGetTemplates(): void
+    public function testParseForcedPlainTextWithJsonPayload(): void
     {
-        $tpl = RTM::getTemplates();
-        foreach (array_keys(RTM::$templates) as $key) {
-            $this->assertArrayHasKey($key, $tpl);
-        }
+        // an explicit non-JSON ResponseFormat forces the plain-text path,
+        // so a JSON payload (no "key=value" lines) is treated as invalid
+        $result = RP::parse('{"status":"SUCCESS"}', ["ResponseFormat" => "TEXT"]);
+        $this->assertSame('FAILURE', $result['status']);
+        $this->assertSame('423 Invalid API response. Contact Support', $result['message']);
     }
 
-    public function testIsTemplateMatchHash(): void
+    public function testParseNonEmptyCmdWithoutResponseFormat(): void
     {
-        $r = new R("");
-        $this->assertTrue(RTM::isTemplateMatchHash($r->getHash(), "empty"));
+        // a non-empty command without ResponseFormat also forces the plain-text path
+        $result = RP::parse('{"status":"SUCCESS"}', ["Command" => "QueryDomainList"]);
+        $this->assertSame('FAILURE', $result['status']);
+        $this->assertSame('423 Invalid API response. Contact Support', $result['message']);
     }
 
-    public function testIsTemplateMatchPlain(): void
-    {
-        $r = new R("");
-        $this->assertTrue(RTM::isTemplateMatchPlain($r->getPlain(), "empty"));
-    }
-
-    public function testAddTemplate(): void
-    {
-        // providing template in plain text
-        $tplid = "custom403";
-        RTM::addTemplate($tplid, "status=FAILURE\r\nmessage=Forbidden\r\n");
-        $this->assertTrue(RTM::hasTemplate($tplid));
-        $tpl = RTM::getTemplate($tplid);
-        $this->assertEquals("FAILURE", $tpl->getStatus());
-        $this->assertEquals("Forbidden", $tpl->getDescription());
-
-        // providing template by status and description
-        $tplid = "custom2_403";
-        RTM::addTemplate($tplid, "FAILURE", "Forbidden");
-        $this->assertTrue(RTM::hasTemplate($tplid));
-        $tpl = RTM::getTemplate($tplid);
-        $this->assertEquals("FAILURE", $tpl->getStatus());
-        $this->assertEquals("Forbidden", $tpl->getDescription());
-    }
-
-    // --- ResponseTranslator tests ---
-
-    public function testPlaceHolderReplacements(): void
-    {
-        // no placeholders left in response when none provided
-        $r = new R("");
-        $this->assertEquals(0, preg_match("/\{[A-Z_]+\}/", $r->getDescription()));
-
-        // placeholder replaced when provided
-        $r = new R("", [], ["CONNECTION_URL" => "123HXPHFOUND123"]);
-        $this->assertStringContainsString("123HXPHFOUND123", $r->getDescription());
-    }
+    // --- Response class: construction and error templates ---
 
     public function testConstructorEmptyResponse(): void
     {
         $r = new R("");
         $this->assertEquals("FAILURE", $r->getStatus());
         $this->assertEquals("423 Empty API response. Probably unreachable API end point", $r->getDescription());
-    }
-
-    public function testInvalidResponse(): void
-    {
-        // JSON without status field
-        $raw = RT::translate('{"somekey":"somevalue"}', []);
-        $r = new R($raw);
-        $this->assertEquals("FAILURE", $r->getStatus());
-        $this->assertEquals("423 Invalid API response. Contact Support", $r->getDescription());
-
-        // plain text without status field
-        $raw2 = RT::translate("somekey=somevalue\r\n", []);
-        $r2 = new R($raw2);
-        $this->assertEquals("FAILURE", $r2->getStatus());
-        $this->assertEquals("423 Invalid API response. Contact Support", $r2->getDescription());
     }
 
     public function testHttpErrorTemplate(): void
@@ -194,7 +170,24 @@ final class ResponseTest extends TestCase
         $this->assertStringContainsString("Connection timed out", $r->getDescription());
     }
 
-    // --- JSON response tests (with ResponseFormat=JSON command) ---
+    public function testNoCurlTemplate(): void
+    {
+        $r = new R("nocurl");
+        $this->assertTrue($r->isError());
+        $this->assertEquals("FAILURE", $r->getStatus());
+        $this->assertStringContainsString("curl_init failed", $r->getDescription());
+    }
+
+    public function testEmptyResponseWithJsonCommand(): void
+    {
+        $cmd = ["ResponseFormat" => "JSON"];
+        $r = new R("", $cmd);
+        $this->assertTrue($r->isError());
+        $this->assertEquals("FAILURE", $r->getStatus());
+        $this->assertStringContainsString("Empty API response", $r->getDescription());
+    }
+
+    // --- Response class: JSON responses (with ResponseFormat=JSON command) ---
 
     public function testJsonSuccessResponse(): void
     {
@@ -262,22 +255,5 @@ final class ResponseTest extends TestCase
 
         // Two records: nameserver is the longest column (length 2)
         $this->assertCount(2, $r->getRecords());
-    }
-
-    public function testNoCurlTemplate(): void
-    {
-        $r = new R("nocurl");
-        $this->assertTrue($r->isError());
-        $this->assertEquals("FAILURE", $r->getStatus());
-        $this->assertStringContainsString("curl_init failed", $r->getDescription());
-    }
-
-    public function testEmptyResponseWithJsonCommand(): void
-    {
-        $cmd = ["ResponseFormat" => "JSON"];
-        $r = new R("", $cmd);
-        $this->assertTrue($r->isError());
-        $this->assertEquals("FAILURE", $r->getStatus());
-        $this->assertStringContainsString("Empty API response", $r->getDescription());
     }
 }

--- a/tests/IBS/ResponseTranslatorTest.php
+++ b/tests/IBS/ResponseTranslatorTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CNICTEST\IBS;
+
+use CNIC\IBS\Response as R;
+use CNIC\IBS\ResponseParser as RP;
+use CNIC\IBS\ResponseTranslator as RT;
+use PHPUnit\Framework\TestCase;
+
+final class ResponseTranslatorTest extends TestCase
+{
+    /**
+     * Test placeholder vars replacement mechanism
+     */
+    public function testPlaceHolderReplacements(): void
+    {
+        // no placeholders left in response when none provided
+        $r = new R("");
+        $this->assertEquals(0, preg_match("/\{[A-Z_]+\}/", $r->getDescription()), "case 1");
+
+        // placeholder replaced when provided
+        $r = new R("", [], ["CONNECTION_URL" => "123HXPHFOUND123"]);
+        $this->assertStringContainsString("123HXPHFOUND123", $r->getDescription(), "case 2");
+    }
+
+    /**
+     * Test that literal lowercase brace content is left untouched
+     * (the placeholder rewrite only targets uppercase {TOKEN} markers)
+     */
+    public function testLiteralLowercaseBracePreserved(): void
+    {
+        $spfValue = "v=spf1 exists:%{i}.spf.hc461-90.ca.test.com -all";
+        $raw = RT::translate("status=SUCCESS\r\nmessage=" . $spfValue . "\r\n", []);
+        $this->assertStringContainsString("message=" . $spfValue, $raw);
+    }
+
+    /**
+     * Test that an empty raw response maps to the "empty" template
+     */
+    public function testEmptyResponseMapsToEmptyTemplate(): void
+    {
+        $raw = RT::translate("", []);
+        $this->assertStringContainsString("status=FAILURE", $raw);
+        $this->assertStringContainsString("Empty API response", $raw);
+    }
+
+    /**
+     * Test explicit static template lookup by id
+     */
+    public function testStaticTemplateLookup(): void
+    {
+        $raw = RT::translate("403", []);
+        $hash = RP::parse($raw);
+        $this->assertSame("FAILURE", $hash["status"]);
+        $this->assertSame("403 Forbidden", $hash["message"]);
+    }
+
+    /**
+     * Test that the curl/HTTP error detail is injected into the {HTTPERROR} slot
+     */
+    public function testHttpErrorPlaceholderSubstituted(): void
+    {
+        $raw = RT::translate("httperror|Connection timed out", []);
+        $this->assertStringContainsString("status=FAILURE", $raw);
+        $this->assertStringContainsString("(Connection timed out)", $raw);
+    }
+
+    /**
+     * Test that all "missing or empty status" variants map to the "invalid" template
+     */
+    public function testInvalidResponseBranches(): void
+    {
+        $expected = "423 Invalid API response. Contact Support";
+
+        // JSON without status field
+        $hash = RP::parse(RT::translate('{"somekey":"somevalue"}', []));
+        $this->assertSame("FAILURE", $hash["status"], "json missing status");
+        $this->assertSame($expected, $hash["message"], "json missing status");
+
+        // plain text without status field
+        $hash = RP::parse(RT::translate("somekey=somevalue\r\n", []));
+        $this->assertSame("FAILURE", $hash["status"], "plain missing status");
+        $this->assertSame($expected, $hash["message"], "plain missing status");
+
+        // JSON with empty status
+        $hash = RP::parse(RT::translate('{"status":""}', []));
+        $this->assertSame("FAILURE", $hash["status"], "json empty status");
+        $this->assertSame($expected, $hash["message"], "json empty status");
+
+        // plain text with empty status
+        $hash = RP::parse(RT::translate("status=\r\n", []));
+        $this->assertSame("FAILURE", $hash["status"], "plain empty status");
+        $this->assertSame($expected, $hash["message"], "plain empty status");
+    }
+
+    /**
+     * Test that a response carrying a non-empty status is returned unchanged
+     */
+    public function testValidStatusPassesThrough(): void
+    {
+        $input = '{"status":"SUCCESS","domain":"ibstest.com"}';
+        $this->assertSame($input, RT::translate($input, ["ResponseFormat" => "JSON"]));
+    }
+}


### PR DESCRIPTION
## Summary

Brings the IBS sub-namespace to test-structure parity with CNR (ref **[RSRMID-2836](https://centralnic.atlassian.net/browse/RSRMID-2836)**).

CNR keeps its parsing units under dedicated `ResponseTranslatorTest` / `ResponseTemplateManagerTest` files; IBS previously lumped parser + translator + template-manager coverage into a single `tests/IBS/ResponseTest.php`. This PR extracts the translator and template-manager tests into dedicated files (mirroring CNR exactly — not duplicated), and expands coverage of the previously-untested branches where the brand-divergent IBS parsing logic lives.

## Changes

- **New `tests/IBS/ResponseTranslatorTest.php`** — placeholder replacement, lowercase-brace preservation, empty→`empty` template, explicit static template lookup, `{HTTPERROR}` substitution, all four missing/empty-status→`invalid` branches, valid-status passthrough.
- **New `tests/IBS/ResponseTemplateManagerTest.php`** — `generateTemplate`, `hasTemplate`, negative `isTemplateMatchHash`/`isTemplateMatchPlain` cases, fluent `addTemplate` chaining, plus the moved baseline tests.
- **`tests/IBS/ResponseTest.php`** — now focuses on the `Response` class + `ResponseParser` (CNR has no dedicated parser test, so parser coverage lives here). Added parser-branch tests: nested-date normalization, empty-string input, case-insensitive `ResponseFormat`, forced plain-text on a JSON payload, and non-empty cmd without `ResponseFormat`.

## Verification

- `composer test` — full suite green; IBS `ResponseParser` and `ResponseTemplateManager` now at 100% line coverage.
- `composer lint` — phpcs + phpstan L9 + psalm L1 + shellcheck all clean.

Note: MONIKER mirroring IBS is intentional and out of scope (per ticket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RSRMID-2836]: https://centralnic.atlassian.net/browse/RSRMID-2836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ