### PR TITLE
build(http): set explicit cURL TLS verification in HttpTransport

### DIFF
--- a/src/HttpTransport.php
+++ b/src/HttpTransport.php
@@ -43,6 +43,8 @@ final class HttpTransport
             CURLOPT_POST            => 1,
             CURLOPT_HEADER          => 0,
             CURLOPT_RETURNTRANSFER  => 1,
+            CURLOPT_SSL_VERIFYPEER  => true, // explicit (cURL default) — verify the peer's certificate
+            CURLOPT_SSL_VERIFYHOST  => 2,    // explicit (cURL default) — certificate host must match
             CURLOPT_POSTFIELDS      => $data,
             CURLOPT_USERAGENT       => $userAgent,
             CURLOPT_HTTPHEADER      => [


### PR DESCRIPTION
## Summary

Pins `CURLOPT_SSL_VERIFYPEER => true` and `CURLOPT_SSL_VERIFYHOST => 2` explicitly in the `curl_setopt_array` defaults in `HttpTransport::post()`.

These values **match cURL's built-in secure defaults**, so runtime behaviour is unchanged for every supported environment. The change is defensive hardening: it documents the secure posture in code and resists environment-level weakening (e.g. stray php.ini / CA configuration).

## Behavioural notes

- **No-op for all standard environments** — verify-peer is already on and verify-host already 2 by libcurl default. All live/OT&E endpoints (CNR, IBS, Moniker) are valid CA-signed HTTPS, so verification keeps succeeding.
- **Now non-overridable** — because the defaults array wins over the merged `$options` (`[...defaults...] + $options`), these two options can no longer be overridden via `extraCurlOpts`. This is the intended lock-on (agreed in review). No current caller passes SSL opts through that path.
- **High-performance path unaffected** — `useHighPerformanceConnectionSetup()` rewrites to `http://127.0.0.1`; cURL ignores SSL options on plain HTTP.

Non-releasing `build` type because there is no behaviour change to ship.

## Testing

- `composer lint` — phpcs + PHPStan L9 + Psalm L1 + shellcheck: clean
- `composer test` — full PHPUnit suite green

Jira: https://centralnic.atlassian.net/browse/RSRMID-2838