### PR TITLE
RSRMID-2841: copyright rename + version-replace and pagination hardening

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -15,9 +15,17 @@
         "replacements": [
           {
             "files": ["src/AbstractClient.php"],
-            "from": "\"\\d+\\.\\d+\\.\\d+\"",
-            "to": "\"${nextRelease.version}\"",
-            "countMatches": true
+            "from": "VERSION = \"\\d+\\.\\d+\\.\\d+\"",
+            "to": "VERSION = \"${nextRelease.version}\"",
+            "countMatches": true,
+            "results": [
+              {
+                "file": "src/AbstractClient.php",
+                "hasChanged": true,
+                "numMatches": 1,
+                "numReplacements": 1
+              }
+            ]
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ declare(strict_types=1);
 
 /**
  * CNIC\<SubNamespace>
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC\<SubNamespace>;

--- a/src/AbstractClient.php
+++ b/src/AbstractClient.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC;
@@ -24,6 +24,12 @@ use CNIC\ResponseInterface;
  */
 abstract class AbstractClient
 {
+    /**
+     * Current module version.
+     * Kept in sync automatically by semantic-release — see .releaserc.json.
+     */
+    private const string VERSION = "16.0.0";
+
     /**
      * context data for the client
      * @var array<string,mixed>
@@ -243,7 +249,7 @@ abstract class AbstractClient
      */
     public function getVersion(): string
     {
-        return "16.0.0";
+        return self::VERSION;
     }
 
     /**

--- a/src/AbstractSocketConfig.php
+++ b/src/AbstractSocketConfig.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC;

--- a/src/CNR/Client.php
+++ b/src/CNR/Client.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC\CNR
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC\CNR;
@@ -78,6 +78,14 @@ class Client extends AbstractClient
         }
         $total = $rr->getRecordsTotalCount();
         $limit = $rr->getRecordsLimitation();
+        // A non-positive page size cannot advance pagination: $first would never
+        // grow, so requestAllResponsePages would loop forever re-requesting the
+        // same page. This is reachable when the caller passes LIMIT=0 (the API
+        // echoes limit=0 with a non-zero total). Treat it as "no further pages",
+        // consistent with getNumberOfPages() which also returns 0 when limit==0.
+        if ($limit <= 0) {
+            return null;
+        }
         $first += $limit;
         if ($first < $total) {
             $mycmd["FIRST"] = $first;

--- a/src/CNR/Column.php
+++ b/src/CNR/Column.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC\CNR
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC\CNR;

--- a/src/CNR/Logger.php
+++ b/src/CNR/Logger.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC\CNR
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC\CNR;

--- a/src/CNR/Record.php
+++ b/src/CNR/Record.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC\CNR
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC\CNR;

--- a/src/CNR/Response.php
+++ b/src/CNR/Response.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC\CNR
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC\CNR;

--- a/src/CNR/ResponseParser.php
+++ b/src/CNR/ResponseParser.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC\CNR
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC\CNR;

--- a/src/CNR/ResponseTemplateManager.php
+++ b/src/CNR/ResponseTemplateManager.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC\CNR
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC\CNR;

--- a/src/CNR/ResponseTranslator.php
+++ b/src/CNR/ResponseTranslator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC\CNR
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC\CNR;

--- a/src/CNR/SessionCapable.php
+++ b/src/CNR/SessionCapable.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC\CNR
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC\CNR;

--- a/src/CNR/SessionClient.php
+++ b/src/CNR/SessionClient.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC\CNR
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC\CNR;

--- a/src/CNR/SocketConfig.php
+++ b/src/CNR/SocketConfig.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC\CNR
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC\CNR;

--- a/src/ClientFactory.php
+++ b/src/ClientFactory.php
@@ -2,6 +2,11 @@
 
 declare(strict_types=1);
 
+/**
+ * CNIC
+ * Copyright © Team Internet Group PLC
+ */
+
 namespace CNIC;
 
 use CNIC\CNR\SessionClient;

--- a/src/ColumnInterface.php
+++ b/src/ColumnInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC;

--- a/src/CommandFormatter.php
+++ b/src/CommandFormatter.php
@@ -2,6 +2,11 @@
 
 declare(strict_types=1);
 
+/**
+ * CNIC
+ * Copyright © Team Internet Group PLC
+ */
+
 namespace CNIC;
 
 /**

--- a/src/HttpTransport.php
+++ b/src/HttpTransport.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC;

--- a/src/IBS/Client.php
+++ b/src/IBS/Client.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC\IBS
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC\IBS;

--- a/src/IBS/Column.php
+++ b/src/IBS/Column.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC\IBS
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC\IBS;

--- a/src/IBS/Logger.php
+++ b/src/IBS/Logger.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC\IBS
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC\IBS;

--- a/src/IBS/Record.php
+++ b/src/IBS/Record.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC\IBS
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC\IBS;

--- a/src/IBS/Response.php
+++ b/src/IBS/Response.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC\IBS
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC\IBS;

--- a/src/IBS/ResponseParser.php
+++ b/src/IBS/ResponseParser.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC\IBS
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC\IBS;

--- a/src/IBS/ResponseTemplateManager.php
+++ b/src/IBS/ResponseTemplateManager.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC\IBS
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC\IBS;

--- a/src/IBS/ResponseTranslator.php
+++ b/src/IBS/ResponseTranslator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC\IBS
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC\IBS;

--- a/src/IBS/SessionClient.php
+++ b/src/IBS/SessionClient.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC\IBS
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC\IBS;

--- a/src/IBS/SocketConfig.php
+++ b/src/IBS/SocketConfig.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC\IBS
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC\IBS;

--- a/src/LoggerInterface.php
+++ b/src/LoggerInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC;

--- a/src/MONIKER/Client.php
+++ b/src/MONIKER/Client.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC\MONIKER
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC\MONIKER;

--- a/src/MONIKER/SessionClient.php
+++ b/src/MONIKER/SessionClient.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC\MONIKER
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC\MONIKER;

--- a/src/MONIKER/SocketConfig.php
+++ b/src/MONIKER/SocketConfig.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC\MONIKER
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC\MONIKER;

--- a/src/RecordInterface.php
+++ b/src/RecordInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC;

--- a/src/Registrar.php
+++ b/src/Registrar.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC;

--- a/src/ResponseInterface.php
+++ b/src/ResponseInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNIC
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  */
 
 namespace CNIC;

--- a/tests/CNR/ClientTest.php
+++ b/tests/CNR/ClientTest.php
@@ -9,6 +9,7 @@ namespace CNICTEST\CNR;
 use CNIC\ClientFactory as CF;
 use CNIC\CNR\Client as CL;
 use CNIC\CNR\Response as R;
+use CNIC\CNR\ResponseTemplateManager as RTM;
 use CNIC\CNR\SessionClient;
 use CNIC\IDNA\Factory\ConverterFactory;
 use PHPUnit\Framework\TestCase;
@@ -617,6 +618,30 @@ final class ClientTest extends TestCase
         $this->assertEquals($r->getRecordsCount(), 2);
         $this->assertEquals($r->getFirstRecordIndex(), 0);
         $this->assertEquals($r->getLastRecordIndex(), 1);
+    }
+
+    public function testRequestNextResponsePageZeroLimit(): void
+    {
+        // Real CNR response shape for `QueryDomainList` with LIMIT = 0:
+        // count/limit come back as 0 while total reflects the full list size.
+        // Without the guard in requestNextResponsePage(), $first never advances
+        // and requestAllResponsePages() would loop forever.
+        RTM::addTemplate(
+            "listLimitZero",
+            "[RESPONSE]\r\nPROPERTY[COUNT][0]=0\r\nPROPERTY[FIRST][0]=0\r\nPROPERTY[LAST][0]=0\r\n"
+            . "PROPERTY[LIMIT][0]=0\r\nPROPERTY[TOTAL][0]=1725494\r\n"
+            . "DESCRIPTION=Command completed successfully\r\nCODE=200\r\nQUEUETIME=0\r\nRUNTIME=0.286\r\nEOF\r\n"
+        );
+        $r = new R("listLimitZero", [
+            "COMMAND" => "QueryDomainList",
+            "FIRST" => "0",
+            "LIMIT" => "0"
+        ]);
+        $this->assertTrue($r->isSuccess());
+        $this->assertSame(0, $r->getRecordsLimitation());
+        $this->assertSame(1725494, $r->getRecordsTotalCount());
+        // The guard must stop pagination rather than re-request the same page.
+        $this->assertNull(self::$cl->requestNextResponsePage($r));
     }
 
     public function testRequestAllResponsePagesOk(): void

--- a/tests/Functional/fixtures/echo.php
+++ b/tests/Functional/fixtures/echo.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * CNICTEST\Functional
- * Copyright © CentralNic Group PLC
+ * Copyright © Team Internet Group PLC
  *
  * Router script for the PHP built-in server used by HttpTransportTest.
  * Echoes selected request details back as JSON so the test can assert which


### PR DESCRIPTION
## Summary

Three improvement opportunities surfaced by a repository review. Jira: [RSRMID-2841](https://centralnic.atlassian.net/browse/RSRMID-2841)

### 1. `chore(license)` — copyright holder rename
Rename `CentralNic Group PLC` → `Team Internet Group PLC` (legal successor) across all `src/` and `tests/` file headers, add the mandated header block to `ClientFactory.php` and `CommandFormatter.php` (which lacked it), and update the file-header template in `CLAUDE.md`.

### 2. `refactor(client)` — version-replace hardening
`getVersion()` returned a bare `"x.y.z"` literal, and the semantic-release replace plugin rewrote **any** quoted `"\d+.\d+.\d+"` in `AbstractClient.php` with `countMatches: true` — a latent footgun where a second version-shaped literal would be silently clobbered on release. Extract a private typed `VERSION` constant (behaviour unchanged), anchor the release regex to `VERSION = "..."`, and add a `results` assertion (`numMatches: 1`) so the release **fails loudly** if the match count ever drifts.

### 3. `fix(client)` — pagination guard against non-positive page size
`requestNextResponsePage()` advanced `$first` by the response `LIMIT`; when `LIMIT = 0` (a caller can pass it; the CNR API echoes `limit=0` with a non-zero `total`), `$first` never advances and `requestAllResponsePages()` loops forever re-requesting the same page. Treat a non-positive page size as "no further pages" and return `null`, consistent with `getNumberOfPages()`. Includes a hermetic, template-driven regression test built from a real `QueryDomainList` `LIMIT=0` response.

## Release impact
Only the `fix(client)` commit triggers a release (patch). The `chore`/`refactor` commits do not.

## Verification
- `composer lint` (phpcs + PHPStan L9 + Psalm L1): clean
- New guard test passes hermetically (no live API call)
- Release-regex replay against the real `.releaserc.json` + edited file: 1 match, rewrites correctly, assertion holds
- Full suite green except live-OTE-API tests, which require API network/credentials available in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RSRMID-2841]: https://centralnic.atlassian.net/browse/RSRMID-2841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ