### PR TITLE
refactor(response): O(1) column lookup, dedupe masking & record assembly

### DIFF
--- a/src/CNR/Response.php
+++ b/src/CNR/Response.php
@@ -31,6 +31,15 @@ class Response implements ResponseInterface
     protected array $command = [];
 
     /**
+     * Command parameter key that carries the account password for this brand.
+     * The value is masked before the command is stored so it can never be read
+     * back (e.g. by custom loggers). Brand-specific by design: CNR uses the
+     * upper-case "PASSWORD", IBS overrides it with "password". A future brand
+     * with a different casing simply declares its own key.
+     */
+    protected string $passwordField = "PASSWORD";
+
+    /**
      * plain API response
      */
     protected string $raw;
@@ -98,7 +107,7 @@ class Response implements ResponseInterface
      */
     public function __construct(string $raw, array $cmd = [], array $ph = [], array $context = [])
     {
-        $cmd = self::sanitizeCommand($cmd);
+        $cmd = $this->sanitizeCommand($cmd);
         $this->context = $context;
         $this->command = $cmd;
         $this->requestUrl = $ph["CONNECTION_URL"] ?? "";
@@ -116,18 +125,16 @@ class Response implements ResponseInterface
     }
 
     /**
-     * Mask password-like command keys so they can no longer be read back from
-     * the response (e.g. by custom loggers). Handles both the upper-case CNR
-     * key and the lower-case IBS key so subclasses share one implementation.
+     * Mask the brand's password command key (see $passwordField) so it can no
+     * longer be read back from the response (e.g. by custom loggers). Shared by
+     * CNR and IBS; the key itself is supplied per-brand via $passwordField.
      * @param array<string, string> $cmd API command used within this request
      * @return array<string, string>
      */
-    protected static function sanitizeCommand(array $cmd): array
+    protected function sanitizeCommand(array $cmd): array
     {
-        foreach (["PASSWORD", "password"] as $key) {
-            if (isset($cmd[$key])) {
-                $cmd[$key] = "***";
-            }
+        if (isset($cmd[$this->passwordField])) {
+            $cmd[$this->passwordField] = "***";
         }
         return $cmd;
     }

--- a/src/CNR/Response.php
+++ b/src/CNR/Response.php
@@ -31,13 +31,16 @@ class Response implements ResponseInterface
     protected array $command = [];
 
     /**
-     * Command parameter key that carries the account password for this brand.
-     * The value is masked before the command is stored so it can never be read
-     * back (e.g. by custom loggers). Brand-specific by design: CNR uses the
-     * upper-case "PASSWORD", IBS overrides it with "password". A future brand
-     * with a different casing simply declares its own key.
+     * Command parameter keys that carry sensitive data for this brand (account
+     * password, domain authorization code, ...). Their values are masked before
+     * the command is stored so they can never be read back (e.g. by custom
+     * loggers). Matching is case-insensitive (see sanitizeCommand()), so only
+     * the names matter, not their casing. Brand-specific by design: CNR uses
+     * upper-case keys, IBS overrides with its own; a future brand simply
+     * declares the keys it uses.
+     * @var string[]
      */
-    protected string $passwordField = "PASSWORD";
+    protected array $sensitiveFields = ["PASSWORD", "AUTH"];
 
     /**
      * plain API response
@@ -125,16 +128,20 @@ class Response implements ResponseInterface
     }
 
     /**
-     * Mask the brand's password command key (see $passwordField) so it can no
-     * longer be read back from the response (e.g. by custom loggers). Shared by
-     * CNR and IBS; the key itself is supplied per-brand via $passwordField.
+     * Mask the brand's sensitive command keys (see $sensitiveFields) so their
+     * values can never be read back from the response (e.g. by custom loggers).
+     * Matching is case-insensitive to stay robust against casing differences
+     * between what a brand documents and what it actually sends.
      * @param array<string, string> $cmd API command used within this request
      * @return array<string, string>
      */
     protected function sanitizeCommand(array $cmd): array
     {
-        if (isset($cmd[$this->passwordField])) {
-            $cmd[$this->passwordField] = "***";
+        $sensitive = array_map("strtolower", $this->sensitiveFields);
+        foreach (array_keys($cmd) as $key) {
+            if (in_array(strtolower($key), $sensitive, true)) {
+                $cmd[$key] = "***";
+            }
         }
         return $cmd;
     }

--- a/src/CNR/Response.php
+++ b/src/CNR/Response.php
@@ -28,7 +28,7 @@ class Response implements ResponseInterface
      * The API Command used within this request
      * @var array<string, string>
      */
-    protected array $command;
+    protected array $command = [];
 
     /**
      * plain API response
@@ -51,30 +51,38 @@ class Response implements ResponseInterface
      * Column names available in this response
      * @var string[]
      */
-    protected array $columnkeys;
+    protected array $columnkeys = [];
 
     /**
      * Container of Column Instances
      * @var ColumnInterface[]
      */
-    protected array $columns;
+    protected array $columns = [];
+
+    /**
+     * Map of column name to its index in the column/columnkeys lists.
+     * Maintained by addColumn() to provide O(1) column lookup. First
+     * occurrence wins, mirroring the previous array_search() behaviour.
+     * @var array<string, int>
+     */
+    protected array $columnindex = [];
 
     /**
      * Record Index we currently point to in record list
      */
-    protected int $recordIndex;
+    protected int $recordIndex = 0;
 
     /**
      * Record List (List of rows)
      * @var Record[]
      */
-    protected array $records;
+    protected array $records = [];
 
     /**
      * Context data for the response
      * @var array<string,mixed>
      */
-    protected array $context;
+    protected array $context = [];
 
     /**
      * API request url
@@ -90,48 +98,65 @@ class Response implements ResponseInterface
      */
     public function __construct(string $raw, array $cmd = [], array $ph = [], array $context = [])
     {
-        if (isset($cmd["PASSWORD"])) { // make password no longer accessible
-            $cmd["PASSWORD"] = "***";
-        }
-
+        $cmd = self::sanitizeCommand($cmd);
         $this->context = $context;
+        $this->command = $cmd;
+        $this->requestUrl = $ph["CONNECTION_URL"] ?? "";
         $this->raw = RT::translate($raw, $cmd, $ph);
         $this->hash = RP::parse($this->raw);
-        $this->requestUrl = $ph["CONNECTION_URL"] ?? "";
-        $this->command = $cmd;
-        $this->columnkeys = [];
-        $this->columns = [];
-        $this->recordIndex = 0;
-        $this->records = [];
 
         $properties = $this->hash["PROPERTY"] ?? null;
         if (is_array($properties)) {
             $colKeys = array_map("strval", array_keys($properties));
-            $count = 0;
             foreach ($colKeys as $k) {
                 $this->addColumn($k, $properties[$k]);
+            }
+            $this->assembleRecords();
+        }
+    }
+
+    /**
+     * Mask password-like command keys so they can no longer be read back from
+     * the response (e.g. by custom loggers). Handles both the upper-case CNR
+     * key and the lower-case IBS key so subclasses share one implementation.
+     * @param array<string, string> $cmd API command used within this request
+     * @return array<string, string>
+     */
+    protected static function sanitizeCommand(array $cmd): array
+    {
+        foreach (["PASSWORD", "password"] as $key) {
+            if (isset($cmd[$key])) {
+                $cmd[$key] = "***";
+            }
+        }
+        return $cmd;
+    }
+
+    /**
+     * Assemble the record (row) list from the columns already added via
+     * addColumn(). Shared by CNR and IBS: each subclass populates the columns
+     * with its own Column type beforehand, while the row assembly is identical.
+     */
+    protected function assembleRecords(): void
+    {
+        $count = 0;
+        foreach ($this->columns as $col) {
+            $count = max($count, count($col->getData()));
+        }
+        for ($i = 0; $i < $count; $i++) {
+            $d = [];
+            foreach ($this->columnkeys as $k) {
                 $col = $this->getColumn($k);
-                if ($col instanceof Column) {
-                    $count2 = $col->length;
-                    if ($count2 > $count) {
-                        $count = $count2;
+                if ($col instanceof ColumnInterface) {
+                    /** @psalm-suppress MixedAssignment getDataByIndex returns mixed by design — IBS columns hold arbitrary JSON values */
+                    $v = $col->getDataByIndex($i);
+                    if ($v !== null) {
+                        /** @psalm-suppress MixedAssignment */
+                        $d[$k] = $v;
                     }
                 }
             }
-            for ($i = 0; $i < $count; $i++) {
-                $d = [];
-                foreach ($colKeys as $k) {
-                    $k .= "";
-                    $col = $this->getColumn($k);
-                    if ($col instanceof Column) {
-                        $v = $col->getDataByIndex($i);
-                        if ($v !== null) {
-                            $d[$k] = $v;
-                        }
-                    }
-                }
-                $this->addRecord($d);
-            }
+            $this->addRecord($d);
         }
     }
 
@@ -267,6 +292,7 @@ class Response implements ResponseInterface
         $col = new Column($key, $data);
         $this->columns[] = $col;
         $this->columnkeys[] = $key;
+        $this->columnindex[$key] ??= count($this->columns) - 1;
         return $this;
     }
 
@@ -289,7 +315,8 @@ class Response implements ResponseInterface
     #[\Override]
     public function getColumn(string $key): ?ColumnInterface
     {
-        return ($this->hasColumn($key) ? $this->columns[array_search($key, $this->columnkeys)] : null);
+        $idx = $this->columnindex[$key] ?? null;
+        return $idx === null ? null : $this->columns[$idx];
     }
 
     /**
@@ -633,7 +660,7 @@ class Response implements ResponseInterface
      */
     protected function hasColumn(string $key): bool
     {
-        return in_array($key, $this->columnkeys);
+        return isset($this->columnindex[$key]);
     }
 
     /**

--- a/src/IBS/Response.php
+++ b/src/IBS/Response.php
@@ -36,6 +36,11 @@ class Response extends CNRResponse implements ResponseInterface
     protected string $paginationkeys = "/^(.+)?count|total(_.+)?$/"; // to be extended
 
     /**
+     * IBS sends the account password under a lower-case command key.
+     */
+    protected string $passwordField = "password";
+
+    /**
      * Constructor
      * @param string $raw API plain response
      * @param array<string, string> $cmd API command used within this request
@@ -44,7 +49,7 @@ class Response extends CNRResponse implements ResponseInterface
      */
     public function __construct(string $raw, array $cmd = [], array $ph = [], array $context = [])
     {
-        $cmd = self::sanitizeCommand($cmd);
+        $cmd = $this->sanitizeCommand($cmd);
         $this->context = $context;
         $this->command = $cmd;
         $this->requestUrl = $ph["CONNECTION_URL"] ?? "";

--- a/src/IBS/Response.php
+++ b/src/IBS/Response.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace CNIC\IBS;
 
 use CNIC\CNR\Response as CNRResponse;
-use CNIC\ColumnInterface;
 use CNIC\IBS\Column as IBSColumn;
 use CNIC\IBS\ResponseParser as RP;
 use CNIC\IBS\ResponseTranslator as RT;
@@ -45,48 +44,21 @@ class Response extends CNRResponse implements ResponseInterface
      */
     public function __construct(string $raw, array $cmd = [], array $ph = [], array $context = [])
     {
-        if (isset($cmd["password"])) { // make password no longer accessible
-            $cmd["password"] = "***";
-        }
-
+        $cmd = self::sanitizeCommand($cmd);
         $this->context = $context;
-        $this->raw = RT::translate($raw, $cmd, $ph);
-        $parsedHash = RP::parse($this->raw, $cmd);
-        $this->hash = $parsedHash;
-        $this->requestUrl = $ph["CONNECTION_URL"] ?? "";
         $this->command = $cmd;
-        $this->columnkeys = [];
-        $this->columns = [];
-        $this->recordIndex = 0;
-        $this->records = [];
+        $this->requestUrl = $ph["CONNECTION_URL"] ?? "";
+        $this->raw = RT::translate($raw, $cmd, $ph);
+        $this->hash = RP::parse($this->raw, $cmd);
 
+        // IBS responses are flat key => value maps; each hash entry becomes a
+        // column. List values are kept as-is, anything else is wrapped into a
+        // single-cell list so the shared record assembly can iterate them.
         $colKeys = array_map("strval", array_keys($this->hash));
-        $count = 0;
         foreach ($colKeys as $k) {
             $this->addColumn($k, is_array($this->hash[$k]) && array_is_list($this->hash[$k]) ? $this->hash[$k] : [$this->hash[$k]]);
-            $col = $this->getColumn($k);
-            if ($col instanceof ColumnInterface) {
-                $count2 = count($col->getData());
-                if ($count2 > $count) {
-                    $count = $count2;
-                }
-            }
         }
-        for ($i = 0; $i < $count; $i++) {
-            $d = [];
-            foreach ($colKeys as $k) {
-                $col = $this->getColumn($k);
-                if ($col instanceof ColumnInterface) {
-                    /** @psalm-suppress MixedAssignment getDataByIndex returns mixed by design — IBS columns hold arbitrary JSON values */
-                    $v = $col->getDataByIndex($i);
-                    if ($v !== null) {
-                        /** @psalm-suppress MixedAssignment */
-                        $d[$k] = $v;
-                    }
-                }
-            }
-            $this->addRecord($d);
-        }
+        $this->assembleRecords();
     }
 
     /**
@@ -192,6 +164,7 @@ class Response extends CNRResponse implements ResponseInterface
         $col = new IBSColumn($key, $data);
         $this->columns[] = $col;
         $this->columnkeys[] = $key;
+        $this->columnindex[$key] ??= count($this->columns) - 1;
         return $this;
     }
 

--- a/src/IBS/Response.php
+++ b/src/IBS/Response.php
@@ -36,9 +36,10 @@ class Response extends CNRResponse implements ResponseInterface
     protected string $paginationkeys = "/^(.+)?count|total(_.+)?$/"; // to be extended
 
     /**
-     * IBS sends the account password under a lower-case command key.
+     * IBS carries sensitive data under lower-/camel-case command keys.
+     * @var string[]
      */
-    protected string $passwordField = "password";
+    protected array $sensitiveFields = ["password", "transferAuthInfo"];
 
     /**
      * Constructor

--- a/tests/CNR/ResponseTest.php
+++ b/tests/CNR/ResponseTest.php
@@ -46,6 +46,22 @@ final class ResponseTest extends TestCase
         $this->assertEquals($expected, $r->getCommandPlain());
     }
 
+    public function testCommandPlainSecureMasksAuthCode(): void
+    {
+        // the domain authorization code (AUTH) is sensitive and must be masked too
+        $r = new R("", ["COMMAND" => "TransferDomain", "DOMAIN" => "test.com", "AUTH" => "secretcode"]);
+        $this->assertEquals("***", $r->getCommand()["AUTH"]);
+    }
+
+    public function testCommandPlainSecureCaseInsensitive(): void
+    {
+        // masking matches sensitive keys case-insensitively, regardless of the casing actually sent
+        $r = new R("", ["COMMAND" => "CheckAuthentication", "password" => "secret", "Auth" => "secretcode"]);
+        $cmd = $r->getCommand();
+        $this->assertEquals("***", $cmd["password"]);
+        $this->assertEquals("***", $cmd["Auth"]);
+    }
+
     public function testGetContext(): void
     {
         $context = ["traceId" => "abc123", "attempt" => 1];

--- a/tests/IBS/ResponseTest.php
+++ b/tests/IBS/ResponseTest.php
@@ -29,6 +29,19 @@ final class ResponseTest extends TestCase
         $this->assertSame($expected, RP::parse($raw));
     }
 
+    public function testCommandSecureMasksSensitiveFields(): void
+    {
+        // password and the transfer auth code are sensitive; masking is case-insensitive
+        $r = new R("{}", [
+            "command" => "RegisterDomain",
+            "password" => "secret",
+            "TransferAuthInfo" => "qCg+ic'G1m"
+        ]);
+        $cmd = $r->getCommand();
+        $this->assertEquals("***", $cmd["password"]);
+        $this->assertEquals("***", $cmd["TransferAuthInfo"]);
+    }
+
     public function testParseResponseWithSpecialCharacters(): void
     {
         $input = [


### PR DESCRIPTION
## Summary

Internal code-quality refactor of the CNR/IBS `Response` classes — **no public API change**. Identified during a repository review and tracked as [RSRMID-2842](https://centralnic.atlassian.net/browse/RSRMID-2842).

### 1. O(1) column lookup
`getColumn()`/`hasColumn()` resolved columns via `array_search()`/`in_array()` over `columnkeys` on every call. Since they run inside the constructor's column/record build loops, response construction was effectively O(n²) in column count. A `columnindex` name→index map (maintained in `addColumn()`) makes both lookups O(1). First-occurrence semantics of `array_search()` are preserved via `??=`.

### 2. Deduplicate & generalise command masking
CNR masked `PASSWORD`, IBS masked `password` — two near-identical copies with divergent key case. This is now a single shared `sanitizeCommand()` on `CNR\Response`, driven by a per-brand `$sensitiveFields` list:

- **CNR**: `["PASSWORD", "AUTH"]`
- **IBS**: `["password", "transferAuthInfo"]`

Masking was broadened beyond the password to **all** sensitive command data (notably the domain authorization code), and matching is now **case-insensitive** so a key is masked regardless of the casing actually sent. A future brand declares its own `$sensitiveFields` — no shared key list to extend. Masking applies to the **command** only, never to response data.

### 3. Deduplicate the constructor
The ~25-line column→record assembly loop was near-identical in both constructors. Extracted to a shared `assembleRecords()` helper. Container properties gained declared defaults (matching the existing `$requestUrl = ""` pattern), so each constructor only wires the request-specific fields. IBS shrank from 45 to ~18 lines.

## Behaviour notes
- Assembly unified on `ColumnInterface` + `count($col->getData())`; identical to CNR's old `instanceof Column` + `$col->length`, since both `Column` classes define `length = count($data)`.
- `$properties` is read before any method call so PHPStan keeps its flow-narrowing of `$this->hash`; index uses `count()-1` (not `array_key_last()`) to stay strictly `int` for Psalm.
- Broadened masking is intentional new behaviour (AUTH / transferAuthInfo are now masked in logged commands); covered by new tests.

## Verification
- `composer lint` (phpcs + phpstan L9 + psalm L1 + shellcheck) — green
- `composer test` — **262 passed, 1 skipped** (pre-existing CNR login skip)
- New tests: CNR `AUTH` masking, CNR case-insensitive matching, IBS `password` + mis-cased `TransferAuthInfo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RSRMID-2842]: https://centralnic.atlassian.net/browse/RSRMID-2842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ