### PR TITLE
ci(tooling): lean dist archive, pin action SHAs, resilient downloads

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,20 +2,28 @@
 # If a file or directory is not excluded using the export-ignore attribute, it will be included in the archive by default.
 
 # directories to exclude
+.claude export-ignore
 .devcontainer export-ignore
 .github export-ignore
+.husky export-ignore
 reports export-ignore
 tests export-ignore
-docs export-ignore 
+docs export-ignore
 build export-ignore
 
 # files to exclude
-.releaserc.json export-ignore
-package.json export-ignore
-pnpm-lock.yaml export-ignore
-*.sh export-ignore
+.editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
+.prettierignore export-ignore
+.prettierrc export-ignore
+.releaserc.json export-ignore
+CLAUDE.md export-ignore
+codecov.yml export-ignore
+package.json export-ignore
+pnpm-lock.yaml export-ignore
+pnpm-workspace.yaml export-ignore
+*.sh export-ignore
 
 # fix language issue in github repo
 *.html linguist-detectable=false

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -17,9 +17,9 @@ jobs:
   rector:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: "8.3"
           coverage: none
@@ -31,7 +31,7 @@ jobs:
         run: composer rector:fix
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore(rector): apply automated modernization fixes"
@@ -44,4 +44,4 @@ jobs:
             **Rulesets applied:** `CODE_QUALITY`, `DEAD_CODE`, `PHP_83`
 
             Triggered by: ${{ github.event_name }}
-          base: master
+          base: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,8 @@ jobs:
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: dorny/paths-filter@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter
         with:
           filters: |

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
     }
   },
   "scripts": {
-    "docs": "rm -rf build/api-cache docs; test -f tools/doctum.phar || (mkdir -p tools && wget -q https://doctum.long-term.support/releases/5.6/doctum.phar -O tools/doctum.phar && echo 'bd9fee08e7672ffdafae294cb064c71b3f6582992a5f87ac9ac9b2bcd44a5fce  tools/doctum.phar' | sha256sum -c && chmod +x tools/doctum.phar); php tools/doctum.phar update .github/doctum.config.php",
+    "docs": "rm -rf build/api-cache docs; test -f tools/doctum.phar || (mkdir -p tools && wget -q --timeout=30 --tries=3 https://doctum.long-term.support/releases/5.6/doctum.phar -O tools/doctum.phar && echo 'bd9fee08e7672ffdafae294cb064c71b3f6582992a5f87ac9ac9b2bcd44a5fce  tools/doctum.phar' | sha256sum -c && chmod +x tools/doctum.phar); php tools/doctum.phar update .github/doctum.config.php",
     "codefix": "phpcbf --ignore=\"*/vendor/*\" --standard=.github/linters/phpcs.xml -q src tests",
     "phpcs": "phpcs --ignore=\"*/vendor/*\" --standard=.github/linters/phpcs.xml -q src tests",
     "lint": [
@@ -77,7 +77,7 @@
     "rector": "rector process --config .github/linters/rector.php --dry-run",
     "rector:fix": "rector process --config .github/linters/rector.php",
     "docs:serve": "php -S 0.0.0.0:8000 -t docs",
-    "generate-uml": "test -f tools/php-class-diagram/vendor/bin/php-class-diagram || (mkdir -p tools/php-class-diagram && composer require --working-dir=tools/php-class-diagram smeghead/php-class-diagram:^1.5); test -f tools/plantuml.jar || (mkdir -p tools && wget -q https://github.com/plantuml/plantuml/releases/download/v1.2026.6/plantuml-1.2026.6.jar -O tools/plantuml.jar && echo '89948f14c93756c7a3fb7b69078ff37e8489fd79dd430c582b931e2f65358690  tools/plantuml.jar' | sha256sum -c); tools/php-class-diagram/vendor/bin/php-class-diagram --jig-diagram src/ > ./docs/uml.puml; java -jar tools/plantuml.jar ./docs/uml.puml -o uml_diagram"
+    "generate-uml": "test -f tools/php-class-diagram/vendor/bin/php-class-diagram || (mkdir -p tools/php-class-diagram && composer require --working-dir=tools/php-class-diagram smeghead/php-class-diagram:^1.5); test -f tools/plantuml.jar || (mkdir -p tools && wget -q --timeout=30 --tries=3 https://github.com/plantuml/plantuml/releases/download/v1.2026.6/plantuml-1.2026.6.jar -O tools/plantuml.jar && echo '89948f14c93756c7a3fb7b69078ff37e8489fd79dd430c582b931e2f65358690  tools/plantuml.jar' | sha256sum -c); tools/php-class-diagram/vendor/bin/php-class-diagram --jig-diagram src/ > ./docs/uml.puml; java -jar tools/plantuml.jar ./docs/uml.puml -o uml_diagram"
   },
   "config": {
     "allow-plugins": {


### PR DESCRIPTION
## Summary

Four self-contained CI/tooling hardening changes from the repository review. **CI behaviour is unchanged.** Tracked as [RSRMID-2845](https://centralnic.atlassian.net/browse/RSRMID-2845).

### A. Lean Composer dist archive (`.gitattributes`)
`export-ignore` controls what Packagist serves as the dist zip (what `composer require` downloads). These dev-only entries were shipping to every consumer and are now excluded: `.claude`, `.husky`, `.editorconfig`, `.prettierrc`, `.prettierignore`, `codecov.yml`, `pnpm-workspace.yaml`, `CLAUDE.md`. Also fixed the trailing space on the `docs` line. `export-ignore` does **not** affect CI (`actions/checkout` pulls the full tree), so there is no CI impact — verified with `git archive HEAD | tar t` (dev artifacts gone, `src/`, `composer.json`, `README`, `LICENSE` retained).

### B. Pin third-party actions to commit SHAs (`test.yml`, `rector.yml`)
The only two workflows that call third-party actions directly. Pinned to immutable SHAs with version comments:
- `actions/checkout@9c091bb…` # v7
- `dorny/paths-filter@fbd0ab8…` # v4
- `shivammathur/setup-php@f3e473d…` # v2
- `peter-evans/create-pull-request@5f6978f…` # v8

The existing Dependabot `github-actions` ecosystem updates pinned SHAs and their comments automatically, so there's no added maintenance.

### C. Resilient tool downloads (`composer.json`)
Added `--timeout=30 --tries=3` to the `doctum.phar` / `plantuml.jar` `wget` calls (`docs`, `generate-uml`) so a transient network blip can't hang the release's docs step. Checksums are still verified.

### D. Portable Rector PR base branch (`rector.yml`)
`base: master` → `base: ${{ github.event.repository.default_branch }}`.

## Verified out of scope
- **`test.yml` keeps `contents: write`** — the shared `php-sdk-test.yml` chains into `auto-merge-dependabot-pr.yml` (needs `contents: write` + `pull-requests: write`); a reusable workflow can't exceed the root caller's token, so the scope is required. Confirmed by reading the shared workflow.
- **Caching / coverage upload / audit gating** live in the shared workflows repo, not here (coverage upload via `codecov-action@v7` in `php-sdk-test.yml`, confirmed).

## Verification
- `composer validate` — valid; `composer lint` — green (no PHP changed)
- `git check-attr export-ignore` confirms the new entries; `git archive` confirms the lean dist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RSRMID-2845]: https://centralnic.atlassian.net/browse/RSRMID-2845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ