### PR TITLE
docs(security): make supported-versions policy version-agnostic

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -2,12 +2,9 @@
 
 ## Supported Versions
 
-Only the latest major release receives security fixes. Older major versions are not actively patched.
+Only the **latest major release** receives security fixes. All earlier major versions are unsupported and will not be patched.
 
-| Version | Supported |
-| ------- | --------- |
-| 15.x    | ✅        |
-| < 15    | ❌        |
+The latest major version is whatever is currently published on [Packagist](https://packagist.org/packages/centralnic-reseller/php-sdk) — upgrade to it to stay on a supported release.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Summary

Resolves the stale **Supported Versions** table in `.github/SECURITY.md`. The table hardcoded `15.x ✅ / < 15 ❌`, but the current release is **16.0.1** — so it marked the actually-supported major (16.x) as unsupported and a dead major (15.x) as supported, contradicting the policy's own "only the latest major receives security fixes" rule.

**Root cause:** the table was static and nothing kept it in sync — `.releaserc.json`'s `semantic-release-replace-plugin` only rewrites the `VERSION` constant in `src/AbstractClient.php`, so the table drifted at every major bump.

**Fix (robust):** replaced the hardcoded table with version-agnostic wording that points at the latest Packagist release, so the policy can never drift on future major bumps — no per-release maintenance required.

## Jira

[RSRMID-2846](https://centralnic.atlassian.net/browse/RSRMID-2846)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RSRMID-2846]: https://centralnic.atlassian.net/browse/RSRMID-2846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ