### PR TITLE
docs(examples): drop stale RRPproxy session-unsupported note

### DIFF
--- a/examples/app_CNR.php
+++ b/examples/app_CNR.php
@@ -49,5 +49,4 @@ if ($r->isSuccess()) {
     }
 } else {
     echo "LOGIN FAILED.\n";
-    echo "NOTE: Session-based communication not yet correctly supported for RRPproxy.";
 }


### PR DESCRIPTION
## Summary

Removes a stale, misleading line from the CNR demo. `examples/app_CNR.php` printed, in the login-failure branch:

> `NOTE: Session-based communication not yet correctly supported for RRPproxy.`

That was true at one point, but CNR now fully supports session-based communication via `CNR\SessionClient` and the `SessionCapable` trait (`login()`/`logout()`). A failed login at that point is simply an auth/credentials failure — the note misleads anyone copying the example into thinking sessions are unsupported, so it's removed. The `LOGIN FAILED.` output remains.

## Jira

[RSRMID-2847](https://centralnic.atlassian.net/browse/RSRMID-2847)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RSRMID-2847]: https://centralnic.atlassian.net/browse/RSRMID-2847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ