### PR TITLE
refactor(response): reuse $paginationkeys in IBS getLastRecordIndex

### DIFF
--- a/src/IBS/Response.php
+++ b/src/IBS/Response.php
@@ -199,7 +199,7 @@ class Response extends CNRResponse implements ResponseInterface
     public function getLastRecordIndex(): ?int
     {
         foreach ($this->columnkeys as $k) {
-            if ((bool)preg_match("/^(.+)?count|total(_.+)?$/", $k)) {
+            if ((bool)preg_match($this->paginationkeys, $k)) {
                 return (is_numeric($this->hash[$k]) ? intval($this->hash[$k], 10) : 0) - 1;
             }
         }


### PR DESCRIPTION
## Summary

`IBS\Response::getLastRecordIndex()` hardcoded the pagination-key regex `/^(.+)?count|total(_.+)?$/` as an inline literal, identical to the `$paginationkeys` property defined on the same class. Because `$paginationkeys` is annotated *"to be extended"*, the inline copy would silently diverge from it once the property is extended.

This change references `$this->paginationkeys` in `getLastRecordIndex()` so the pattern has a single source of truth.

## Scope

- Internal refactor only — no behaviour change.
- Covered by existing IBS response navigation tests (112 IBS tests pass; `composer lint` clean).

## Jira

https://centralnic.atlassian.net/browse/RSRMID-2850

🤖 Generated with [Claude Code](https://claude.com/claude-code)