### PR TITLE
refactor(response): make IBS isSuccess() the documented complement of isError()

### DIFF
--- a/src/IBS/Response.php
+++ b/src/IBS/Response.php
@@ -121,7 +121,13 @@ class Response extends CNRResponse implements ResponseInterface
     }
 
     /**
-     * Check if current API response represents an error case
+     * Check if current API response represents an error case.
+     *
+     * FAILURE is the only IBS status that signals an error. Every other status
+     * means the command itself succeeded — "SUCCESS" for ordinary commands, and
+     * for Domain/Check specifically "AVAILABLE"/"UNAVAILABLE", which report the
+     * domain's registrability rather than a failure. Missing/empty statuses are
+     * normalised to FAILURE upstream by ResponseTranslator's fallback templates.
      */
     #[\Override]
     public function isError(): bool
@@ -130,12 +136,16 @@ class Response extends CNRResponse implements ResponseInterface
     }
 
     /**
-     * Check if current API response represents a success case
+     * Check if current API response represents a success case.
+     *
+     * The complement of isError(): any non-FAILURE status (SUCCESS, AVAILABLE,
+     * UNAVAILABLE, ...) is a success. See isError() for why FAILURE is the sole
+     * error signal.
      */
     #[\Override]
     public function isSuccess(): bool
     {
-        return ($this->getHashString("status") === "SUCCESS" || !$this->isError());
+        return !$this->isError();
     }
 
     /**


### PR DESCRIPTION
## Summary

`IBS\Response::isSuccess()` read `status === "SUCCESS" || !isError()`. Since `isError()` is `status === "FAILURE"`, the `=== "SUCCESS"` operand can **never** change the result — it is provably dead for every status value, and it reads as if `SUCCESS` were special when it is not.

The actual IBS semantics (confirmed with the maintainer): **`FAILURE` is the sole error signal.** Every other status means the command itself succeeded — `SUCCESS` for ordinary commands, and for `Domain/Check` specifically `AVAILABLE`/`UNAVAILABLE`, which report the domain's registrability rather than a failure. Missing/empty statuses are normalised to `FAILURE` upstream by `ResponseTranslator`'s fallback templates.

This change:
- makes `isSuccess()` return `!isError()`, giving `FAILURE` a single source of truth;
- documents the `Domain/Check` (`AVAILABLE`/`UNAVAILABLE`) rationale on `isError()` so the intent is visible.

## Scope

- Behaviourally **identical** to today for all inputs (`SUCCESS`, `AVAILABLE`, `UNAVAILABLE`, `FAILURE`, empty) — pure clarity refactor.
- Covered by existing IBS response tests (112 IBS tests pass; `composer lint` clean).

## Jira

https://centralnic.atlassian.net/browse/RSRMID-2851

🤖 Generated with [Claude Code](https://claude.com/claude-code)