### PR TITLE
refactor(response): reuse $limit in CNR getNumberOfPages()

### DIFF
--- a/src/CNR/Response.php
+++ b/src/CNR/Response.php
@@ -512,7 +512,7 @@ class Response implements ResponseInterface
         $t = $this->getRecordsTotalCount();
         $limit = $this->getRecordsLimitation();
         if ($t && $limit) {
-            return (int)ceil($t / $this->getRecordsLimitation());
+            return (int)ceil($t / $limit);
         }
         return 0;
     }


### PR DESCRIPTION
## Summary

`CNR\Response::getNumberOfPages()` stored `getRecordsLimitation()` in a local `$limit` for the guard check, then called `getRecordsLimitation()` a **second** time inside the `ceil()` expression instead of reusing the local. The two calls always return the same value, so the second was redundant work.

```diff
 $t = $this->getRecordsTotalCount();
 $limit = $this->getRecordsLimitation();
 if ($t && $limit) {
-    return (int)ceil($t / $this->getRecordsLimitation());
+    return (int)ceil($t / $limit);
 }
```

## Scope

- Pure internal cleanup — no behaviour change.
- Full test suite green (285 passed, 1 deliberately skipped); `composer lint` clean.

## Jira

https://centralnic.atlassian.net/browse/RSRMID-2852

🤖 Generated with [Claude Code](https://claude.com/claude-code)