### PR TITLE
fix(response): anchor CNR pagination-key regex to exact keys

### DIFF
--- a/src/CNR/Response.php
+++ b/src/CNR/Response.php
@@ -54,10 +54,14 @@ class Response implements ResponseInterface
     protected array $hash;
 
     /**
-     * Regex for pagination related column keys
+     * Regex for pagination related column keys.
+     * The alternation is grouped so the ^…$ anchors apply to every keyword;
+     * without the group only TOTAL/LAST are anchored and COUNT|LIMIT|FIRST
+     * would match anywhere, wrongly stripping real columns such as COUNTRY,
+     * FIRSTNAME, DISCOUNT or ACCOUNT from getColumnKeys()/getListHash().
      * @var non-empty-string
      */
-    protected string $paginationkeys = "/^TOTAL|COUNT|LIMIT|FIRST|LAST$/";
+    protected string $paginationkeys = "/^(TOTAL|COUNT|LIMIT|FIRST|LAST)$/";
 
     /**
      * Column names available in this response

--- a/tests/CNR/ResponseTest.php
+++ b/tests/CNR/ResponseTest.php
@@ -165,6 +165,51 @@ final class ResponseTest extends TestCase
         $this->assertEquals($lh["meta"]["pg"], $r->getPagination());
     }
 
+    public function testPaginationKeysDoNotStripRealColumns(): void
+    {
+        // RSRMID-2854: columns whose names merely *contain* a pagination keyword
+        // as a substring (COUNTRY -> COUNT, FIRSTNAME -> FIRST) must NOT be
+        // treated as pagination metadata. Only the exact keys TOTAL/COUNT/LIMIT/
+        // FIRST/LAST are pagination columns and get stripped by getColumnKeys(true)
+        // and getListHash().
+        $raw = implode("\r\n", [
+            "[RESPONSE]",
+            "CODE=200",
+            "DESCRIPTION=Command completed successfully",
+            "PROPERTY[TOTAL][0]=2",
+            "PROPERTY[FIRST][0]=0",
+            "PROPERTY[LAST][0]=1",
+            "PROPERTY[COUNT][0]=2",
+            "PROPERTY[LIMIT][0]=2",
+            "PROPERTY[FIRSTNAME][0]=Adrian",
+            "PROPERTY[FIRSTNAME][1]=John",
+            "PROPERTY[COUNTRY][0]=PL",
+            "PROPERTY[COUNTRY][1]=US",
+            "EOF"
+        ]);
+        $r = new R($raw);
+
+        // unfiltered keys list everything
+        $allKeys = $r->getColumnKeys();
+        $this->assertContains("FIRSTNAME", $allKeys);
+        $this->assertContains("COUNTRY", $allKeys);
+
+        // filtered keys keep the real columns but drop the genuine pagination keys
+        $filtered = $r->getColumnKeys(true);
+        $this->assertContains("FIRSTNAME", $filtered);
+        $this->assertContains("COUNTRY", $filtered);
+        foreach (["TOTAL", "COUNT", "LIMIT", "FIRST", "LAST"] as $pgKey) {
+            $this->assertNotContains($pgKey, $filtered);
+        }
+
+        // list hash rows retain the real columns and drop the pagination keys
+        $lh = $r->getListHash();
+        $this->assertSame(["columns", "pg"], array_keys($lh["meta"]));
+        $this->assertEquals($filtered, $lh["meta"]["columns"]);
+        $this->assertSame(["FIRSTNAME" => "Adrian", "COUNTRY" => "PL"], $lh["LIST"][0]);
+        $this->assertSame(["FIRSTNAME" => "John", "COUNTRY" => "US"], $lh["LIST"][1]);
+    }
+
     public function testGetNextRecord(): void
     {
         $r = new R("listP0");


### PR DESCRIPTION
## Summary

Fixes a correctness bug in `CNR\Response`: the pagination-key regex silently stripped real data columns from list output.

The property was:

```php
protected string $paginationkeys = "/^TOTAL|COUNT|LIMIT|FIRST|LAST$/";
```

Regex alternation binds looser than the `^`/`$` anchors, so this parsed as `^TOTAL` OR `COUNT` OR `LIMIT` OR `FIRST` OR `LAST$`. Only `TOTAL` was anchored at the start and only `LAST` at the end — the middle keywords matched **anywhere** in a column name.

As a result, genuine columns were wrongly classified as pagination metadata and dropped by `getColumnKeys(true)` and `getListHash()`:

| column | matched | real CNR column? |
|--------|---------|------------------|
| `COUNTRY` | contains `COUNT` | yes — contact lists |
| `FIRSTNAME` | contains `FIRST` | yes — contact lists |
| `DISCOUNT`, `ACCOUNT`, `LIMITED`, `BLAST` | — | further false positives |

## Fix

Group the alternation so the anchors apply to every keyword:

```php
protected string $paginationkeys = "/^(TOTAL|COUNT|LIMIT|FIRST|LAST)$/";
```

Behaviour-preserving for the genuine pagination keys (they remain exact matches and are still stripped); only the substring false positives stop being dropped.

## Tests

- New regression test `testPaginationKeysDoNotStripRealColumns` asserts `COUNTRY`/`FIRSTNAME` survive `getColumnKeys(true)` and `getListHash()`, while the exact keys `TOTAL/COUNT/LIMIT/FIRST/LAST` are still removed.
- Full suite: 286 passed, 1 pre-existing skip. `phpcs` / `phpstan` (L9) / `psalm` (L1) all clean.

## Scope

`IBS\Response` has a structurally similar (looser) regex. It is intentionally **out of scope** here and will be analysed separately.

## Jira

[RSRMID-2854](https://centralnic.atlassian.net/browse/RSRMID-2854)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[RSRMID-2854]: https://centralnic.atlassian.net/browse/RSRMID-2854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ