### PR TITLE
fix(response): ground IBS getLastRecordIndex in count, anchor pagination regex

### DIFF
--- a/src/IBS/Response.php
+++ b/src/IBS/Response.php
@@ -30,10 +30,24 @@ use CNIC\ResponseInterface;
 class Response extends CNRResponse implements ResponseInterface
 {
     /**
-     * Regex for pagination related column keys
+     * Regex for the count/metadata column keys IBS emits alongside a list.
+     *
+     * Derived from the real IBS list endpoints: Domain/List carries
+     * "domaincount", while Url-/EmailForward/List use "total_rules" and
+     * DnsRecord/List "total_records". The alternation is fully anchored so it
+     * matches those keys exactly and never as a substring. In particular the
+     * loose ".*count" form is avoided on purpose: Domain/Count returns one
+     * top-level key per TLD the reseller holds, and ".discount" is a real gTLD,
+     * so a key literally named "discount" can occur and must NOT be treated as
+     * metadata. "totaldomains" (Domain/Count's grand total) is intentionally
+     * NOT matched either — it is meaningful aggregate data, not list metadata.
+     *
+     * Used only to strip these columns in getColumnKeys(true)/getListHash().
+     * It does NOT drive getLastRecordIndex(): IBS returns the full result set
+     * in a single page, so the last index is the record-grounded count - 1.
      * @var non-empty-string
      */
-    protected string $paginationkeys = "/^(.+)?count|total(_.+)?$/"; // to be extended
+    protected string $paginationkeys = "/^(total_.*|domaincount)$/";
 
     /**
      * IBS carries sensitive data under lower-/camel-case command keys.
@@ -208,12 +222,21 @@ class Response extends CNRResponse implements ResponseInterface
     #[\Override]
     public function getLastRecordIndex(): ?int
     {
-        foreach ($this->columnkeys as $k) {
-            if ((bool)preg_match($this->paginationkeys, $k)) {
-                return (is_numeric($this->hash[$k]) ? intval($this->hash[$k], 10) : 0) - 1;
-            }
+        // IBS returns the full result set in a single page — there is no
+        // limit/offset/page cursor — so the last index is simply count - 1,
+        // grounded in the actual record list (mirrors CNR\Response).
+        //
+        // We deliberately do NOT derive this from a "count" column (e.g.
+        // domaincount, total_rules, total_records). That field equals the row
+        // count when the list is populated (so it is redundant), but on an
+        // empty list it is 0 while the meta keys (transactid/status/...) still
+        // form one record — which made the old count-key logic underflow LAST
+        // to -1, contradicting FIRST=0/COUNT=1. Grounding LAST in the records
+        // keeps the pagination block internally coherent in every case.
+        $c = $this->getRecordsCount();
+        if ($c !== 0) {
+            return $c - 1;
         }
-
         return null;
     }
 

--- a/tests/IBS/ResponseNavigationTest.php
+++ b/tests/IBS/ResponseNavigationTest.php
@@ -19,12 +19,13 @@ final class ResponseNavigationTest extends TestCase
     private const JSONCMD = ["ResponseFormat" => "JSON"];
 
     /**
-     * A three-record list response: the "domain" list column drives the
-     * record count, "total" is a pagination/count column.
+     * A three-record list response mirroring Domain/List: the "domain" list
+     * column drives the record count, "domaincount" is the count/metadata
+     * column stripped by getColumnKeys(true).
      */
     private function listResponse(): R
     {
-        $json = '{"status":"SUCCESS","total":3,"domain":["a.com","b.com","c.com"]}';
+        $json = '{"status":"SUCCESS","domaincount":3,"domain":["a.com","b.com","c.com"]}';
         return new R($json, self::JSONCMD);
     }
 
@@ -100,7 +101,7 @@ final class ResponseNavigationTest extends TestCase
         $this->assertEquals(3, $pg["COUNT"]);
         $this->assertEquals(1, $pg["CURRENTPAGE"]);
         $this->assertEquals(0, $pg["FIRST"]);
-        $this->assertEquals(2, $pg["LAST"]); // total(3) - 1
+        $this->assertEquals(2, $pg["LAST"]); // recordsCount(3) - 1
         $this->assertEquals(3, $pg["LIMIT"]);
         $this->assertEquals(1, $pg["PAGES"]);
         $this->assertEquals(1, $pg["NEXTPAGE"]); // clamped to the last page
@@ -122,11 +123,11 @@ final class ResponseNavigationTest extends TestCase
 
     public function testGetLastRecordIndexIsComputedPerInstance(): void
     {
-        // Two independent responses with different count columns. Before the fix
+        // Two independent responses with different record counts. Before the fix
         // a method-scoped `static $last` cached the first result and poisoned the
-        // second (returning null). Each must now report its own value.
-        $a = new R('{"status":"SUCCESS","total":5,"item":["x"]}', self::JSONCMD);
-        $b = new R('{"status":"SUCCESS","total":2,"item":["y"]}', self::JSONCMD);
+        // second (returning null). Each must now report its own count - 1.
+        $a = new R('{"status":"SUCCESS","item":["a","b","c","d","e"]}', self::JSONCMD); // 5 rows
+        $b = new R('{"status":"SUCCESS","item":["x","y"]}', self::JSONCMD);             // 2 rows
 
         $this->assertEquals(4, $a->getLastRecordIndex()); // 5 - 1
         $this->assertEquals(1, $b->getLastRecordIndex()); // 2 - 1
@@ -134,10 +135,14 @@ final class ResponseNavigationTest extends TestCase
         $this->assertEquals(4, $a->getLastRecordIndex());
     }
 
-    public function testGetLastRecordIndexNullWithoutCountColumn(): void
+    public function testGetLastRecordIndexFallsBackToCountWithoutCountColumn(): void
     {
+        // No pagination/count column: fall back to the single-page model and
+        // report count - 1 (mirrors CNR\Response), so FIRST/LAST form a coherent
+        // pair instead of FIRST=0 / LAST=null. Here the response holds a single
+        // record, so the last index is 0.
         $r = new R('{"status":"SUCCESS","domain":["a.com"]}', self::JSONCMD);
-        $this->assertNull($r->getLastRecordIndex());
+        $this->assertEquals(0, $r->getLastRecordIndex());
     }
 
     // --- column access ---
@@ -153,9 +158,33 @@ final class ResponseNavigationTest extends TestCase
     public function testGetColumnKeysFiltersPaginationColumns(): void
     {
         $r = $this->listResponse();
-        $this->assertEquals(["status", "total", "domain"], $r->getColumnKeys());
-        // the "total" pagination/count column is stripped when filtering
+        $this->assertEquals(["status", "domaincount", "domain"], $r->getColumnKeys());
+        // the "domaincount" count/metadata column is stripped when filtering
         $this->assertEquals(["status", "domain"], $r->getColumnKeys(true));
+    }
+
+    /**
+     * Lock in the anchored pagination-key regex against the real IBS column
+     * shapes. The count/metadata keys emitted by the list endpoints
+     * (domaincount, total_rules, total_records) must be stripped, while
+     * genuine data columns that merely contain those substrings must not be
+     * — including "totaldomains" (Domain/Count's aggregate sum) and a TLD key
+     * literally named "discount" (".discount" is a real gTLD in Domain/Count).
+     */
+    public function testGetColumnKeysFilteringMatchesRealKeyShapes(): void
+    {
+        // stripped: the documented count/metadata keys
+        foreach (["domaincount", "total_rules", "total_records"] as $key) {
+            $r = new R('{"status":"SUCCESS","' . $key . '":2,"domain":["a.com","b.com"]}', self::JSONCMD);
+            $this->assertNotContains($key, $r->getColumnKeys(true), "$key should be stripped");
+        }
+
+        // kept: aggregate data and substring look-alikes must survive filtering
+        $r = new R('{"status":"SUCCESS","com":2655,"discount":4,"totaldomains":4142}', self::JSONCMD);
+        $kept = $r->getColumnKeys(true);
+        foreach (["status", "com", "discount", "totaldomains"] as $key) {
+            $this->assertContains($key, $kept, "$key must not be stripped");
+        }
     }
 
     public function testGetCommandAndPlain(): void


### PR DESCRIPTION
## Summary

Fixes the IBS pagination handling flagged in [RSRMID-2855](https://centralnic.atlassian.net/browse/RSRMID-2855), validated against real IBS API responses (Domain/Count, Domain/List, Url-/EmailForward/List, DnsRecord/List, Account/Balance, Account/PriceList).

The analysis confirmed **IBS does not paginate** — every list endpoint returns the full result set in a single page, and the "count" field is just the row count.

### Changes

**1. `getLastRecordIndex()` — record-grounded `count - 1` (fallback-only)**

Dropped the count-key-driven derivation. The old logic looped for a pagination-key match and returned `countKey - 1`, which **underflowed `LAST` to `-1`** on empty lists (`total_rules`/`total_records` = 0) while the meta keys (`transactid`/`status`) still formed one record — contradicting `FIRST=0`/`COUNT=1`. `LAST` is now grounded in the actual record list, coherent in every shape.

**2. Pagination-key regex — anchored**

```
/^(.+)?count|total(_.+)?$/   ->   /^(total_.*|domaincount)$/
```

The old alternation matched substrings (`accountname`, `subtotal`, `discount`, …) yet **missed the real count keys** in some forms. The regex now serves a single job — stripping count/metadata columns in `getColumnKeys(true)`/`getListHash()` — and matches the real IBS keys (`domaincount`, `total_rules`, `total_records`) exactly. It intentionally **keeps** `totaldomains` (Domain/Count's aggregate sum, legitimate data) and a TLD key literally named `discount` (`.discount` is a real gTLD that surfaces as a top-level key in Domain/Count).

### Real-key behavior matrix

| Endpoint | count key | stripped from `getColumnKeys(true)` | `FIRST/LAST` |
|---|---|---|---|
| Domain/Count | `totaldomains` | no (kept — aggregate data) | 0 / 0 |
| Domain/List | `domaincount` | yes | 0 / n-1 |
| UrlForward/List (empty) | `total_rules` | yes | 0 / 0 |
| EmailForward/List (empty) | `total_rules` | yes | 0 / 0 |
| DnsRecord/List | `total_records` | yes | 0 / n-1 |
| Account/Balance, PriceList | — | nothing | 0 / 0 |

### Tests

- Retargeted the `listResponse()` fixture to a realistic `domaincount` key.
- Updated the per-instance and column-filter tests to the new contract.
- Added `testGetColumnKeysFilteringMatchesRealKeyShapes` locking in the strip/keep behavior against the real IBS key shapes (incl. `discount`/`totaldomains` guards).

113 IBS tests pass · phpstan ✅ · psalm ✅ · phpcs ✅


[RSRMID-2855]: https://centralnic.atlassian.net/browse/RSRMID-2855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ