### PR TITLE
refactor(response): correct $cmd PHPDoc type to array<string, string>

### DIFF
--- a/src/CNR/ResponseTranslator.php
+++ b/src/CNR/ResponseTranslator.php
@@ -45,7 +45,7 @@ final class ResponseTranslator
     /**
      * translate a raw api response
      * @param string $raw API raw response
-     * @param array<string> $cmd requested API command
+     * @param array<string, string> $cmd requested API command
      * @param array{CONNECTION_URL?: string} $ph list of place holder vars
      */
     public static function translate(string $raw, array $cmd, array $ph = []): string
@@ -113,7 +113,7 @@ final class ResponseTranslator
      * @param string $regex The regular expression pattern to search for.
      * @param string $newraw The input text where the match will be searched for and replacements applied.
      * @param string $val The value to be used in replacement if a match is found.
-     * @param array<string> $cmd The command data containing replacements, if applicable.
+     * @param array<string, string> $cmd The command data containing replacements, if applicable.
      */
     private static function findMatch(string $regex, string &$newraw, string $val, array $cmd): bool
     {

--- a/src/IBS/ResponseParser.php
+++ b/src/IBS/ResponseParser.php
@@ -20,7 +20,7 @@ final class ResponseParser
     /**
      * Method to parse API response into associative array
      * @param string $raw API response
-     * @param array<string> $cmd API command used within this request
+     * @param array<string, string> $cmd API command used within this request
      * @return array<string,mixed>
      */
     public static function parse(string $raw, array $cmd = []): array

--- a/src/IBS/ResponseTranslator.php
+++ b/src/IBS/ResponseTranslator.php
@@ -39,7 +39,7 @@ final class ResponseTranslator
     /**
      * translate a raw api response
      * @param string $raw API raw response
-     * @param array<string> $cmd requested API command
+     * @param array<string, string> $cmd requested API command
      * @param array{CONNECTION_URL?: string} $ph list of place holder vars
      * @psalm-suppress UnusedParam $cmd kept for API consistency with CNR\ResponseTranslator
      */


### PR DESCRIPTION
## Summary

Several methods documented `$cmd` as `@param array<string>` (a list of strings) but actually index it by **string key**, so the accurate type is `array<string, string>`. Doc-only inaccuracy — no runtime or static-analysis impact.

The value reaching these methods is the post-`flattenCommand` map, whose own return type is already `array<string,string>`, so this aligns the docblocks with what is actually passed in (and with `Response`, whose `$command` property, constructor, `getCommand()`, and `ResponseInterface` contract were all already `array<string, string>`).

## Changes

- `IBS\ResponseParser::parse()`
- `IBS\ResponseTranslator::translate()`
- `CNR\ResponseTranslator::translate()` and `findMatch()`

## Verification

- `composer phpstan` (L9) — clean
- `composer psalm` (L1) — clean

Jira: https://centralnic.atlassian.net/browse/RSRMID-2856