### PR TITLE
refactor(cnr): drop redundant empty array in requestAllResponsePages merge

### DIFF
--- a/src/CNR/Client.php
+++ b/src/CNR/Client.php
@@ -103,7 +103,7 @@ class Client extends AbstractClient
     public function requestAllResponsePages(array $cmd): array
     {
         $responses = [];
-        $rr = $this->request(array_merge([], $cmd, ["FIRST" => 0]));
+        $rr = $this->request(array_merge($cmd, ["FIRST" => 0]));
         $tmp = $rr;
         $idx = 0;
         do {


### PR DESCRIPTION
## Summary

Trivial cleanup in `src/CNR/Client.php`. `requestAllResponsePages()` merged with a superfluous empty array as the first argument:

```php
$rr = $this->request(array_merge([], $cmd, ["FIRST" => 0]));
```

The leading `[]` is a no-op; `array_merge($cmd, ["FIRST" => 0])` is equivalent and clearer. No behaviour change.

## Verification

- `composer lint` — phpcs + phpstan (level 9) + psalm (level 1): no errors
- `composer test` — full PHPUnit suite passes

## Jira

[RSRMID-2857](https://centralnic.atlassian.net/browse/RSRMID-2857)


[RSRMID-2857]: https://centralnic.atlassian.net/browse/RSRMID-2857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ