### PR TITLE
refactor(response): drop dead hasColumn() method

### DIFF
--- a/src/CNR/Response.php
+++ b/src/CNR/Response.php
@@ -673,15 +673,6 @@ class Response implements ResponseInterface
     }
 
     /**
-     * Check if column exists in response
-     * @param string $key column name
-     */
-    protected function hasColumn(string $key): bool
-    {
-        return isset($this->columnindex[$key]);
-    }
-
-    /**
      * Check if the record list contains a record for the
      * current record index in use
      */

--- a/src/ResponseInterface.php
+++ b/src/ResponseInterface.php
@@ -268,13 +268,6 @@ interface ResponseInterface
     public function rewindRecordList(): ResponseInterface;
 
     /**
-     * Check if column exists in response
-     * @param string $key column name
-     * @return bool boolean result
-     */
-    //private function hasColumn($key): bool;
-
-    /**
      * Check if the record list contains a record for the
      * current record index in use
      * @return bool boolean result


### PR DESCRIPTION
## What

Removes the protected `hasColumn()` method from `CNR\Response` and its matching commented-out stub in `ResponseInterface`.

## Why

`hasColumn()` has **zero call sites** in `src/` or `tests/`. It was orphaned when the O(1) column lookup (the `$columnindex` map) replaced the `array_search`-based helpers. Psalm's `findUnusedCode` does not flag it because it is `protected` on a non-final class, but neither `CNR\Response` nor `IBS\Response` (which inherits it) uses it. Callers already get the same existence signal from `getColumn()`, which returns `null` for a missing column.

Behaviour-neutral; non-releasing `refactor`.

## Verification

- `composer lint` clean (phpcs + PHPStan L9 + Psalm L1 + shellcheck)
- Full suite green (287 passed, 1 pre-existing skip)

## Jira

https://centralnic.atlassian.net/browse/RSRMID-2859