### PR TITLE
chore(rector): apply automated modernization fixes

### DIFF
--- a/tests/CNR/ClientTest.php
+++ b/tests/CNR/ClientTest.php
@@ -405,7 +405,12 @@ final class ClientTest extends TestCase
                     IDNA_DEFAULT,
                 INTL_IDNA_VARIANT_UTS46
             );
-            $this->assertEquals($ace, $tmp, "Failure: " . $idn . " -> " . (string) $tmp . " vs. " . $ace);
+            // idn_to_ascii() returns string|false; a false here is a genuine
+            // conversion failure, not an empty result. Assert it away first so
+            // the message below concatenates a real string (no cast needed) and
+            // a failure reads clearly instead of as an empty conversion.
+            $this->assertNotFalse($tmp, "idn_to_ascii() failed for: " . $idn);
+            $this->assertEquals($ace, $tmp, "Failure: " . $idn . " -> " . $tmp . " vs. " . $ace);
         }
     }
 

--- a/tests/Functional/HttpTransportTest.php
+++ b/tests/Functional/HttpTransportTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 final class HttpTransportTest extends TestCase
 {
     /** @var resource|null */
-    private static $proc = null;
+    private static $proc;
     /** @var array<array-key,resource> */
     private static array $pipes = [];
     private static string $url = "";

--- a/tests/IBS/ResponseNavigationTest.php
+++ b/tests/IBS/ResponseNavigationTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 final class ResponseNavigationTest extends TestCase
 {
     /** @var array<string,string> command forcing JSON parsing */
-    private const JSONCMD = ["ResponseFormat" => "JSON"];
+    private const array JSONCMD = ["ResponseFormat" => "JSON"];
 
     /**
      * A three-record list response mirroring Domain/List: the "domain" list


### PR DESCRIPTION
## What

Applies all three pending Rector (PHP 8.3) modernization suggestions in the test suite:

- **AddTypeToConstRector** — type the `JSONCMD` class constant in `tests/IBS/ResponseNavigationTest`.
- **RemoveNullPropertyInitializationRector** — drop the redundant `= null` on the static `$proc` property in `tests/Functional/HttpTransportTest`.
- **RemoveConcatAutocastRector** — drop the `(string)` cast on `$tmp` in `tests/CNR/ClientTest::testIdnaToAscii`.

## Why the third needed care

`idn_to_ascii()` returns `string|false`, so removing the cast alone made Psalm (level 1) fail with `PossiblyFalseOperand`. The cast was also masking a real conversion failure as an empty string (`(string) false === ""`).

Rather than keep the cast, the line now asserts `assertNotFalse($tmp, ...)` first — this fails with a clear message on a genuine conversion failure **and** narrows `$tmp` to `string`, so the message concatenation needs no cast. Net result: Psalm-clean, `composer rector` reports nothing to do, and the monthly `rector.yml` job stays green.

## Verification

- `composer lint` clean (phpcs + PHPStan L9 + Psalm L1 + shellcheck)
- `composer rector` → "Rector is done!" (no remaining diffs)
- Full suite green (287 passed, 1 pre-existing skip)

## Jira

https://centralnic.atlassian.net/browse/RSRMID-2860