### PR TITLE
refactor(client): drop unintended "0" reset sentinel in config setters

### DIFF
--- a/src/AbstractClient.php
+++ b/src/AbstractClient.php
@@ -199,7 +199,7 @@ abstract class AbstractClient
      */
     public function setProxy(string $proxy = ""): static
     {
-        if ($proxy === '' || $proxy === '0') {
+        if ($proxy === '') {
             unset($this->curlopts[CURLOPT_PROXY]);
         } else {
             $this->curlopts[CURLOPT_PROXY] = $proxy;
@@ -225,7 +225,7 @@ abstract class AbstractClient
      */
     public function setReferer(string $referer = ""): static
     {
-        if ($referer === '' || $referer === '0') {
+        if ($referer === '') {
             unset($this->curlopts[CURLOPT_REFERER]);
         } else {
             $this->curlopts[CURLOPT_REFERER] = $referer;
@@ -297,7 +297,7 @@ abstract class AbstractClient
     public function setRoleCredentials(string $uid = "", string $role = "", string $pw = ""): static
     {
         $login = $uid;
-        if ($role !== '' && $role !== '0') {
+        if ($role !== '') {
             $login .= $this->socketConfig->getRoleSeparator() . $role;
         }
         return $this->setCredentials($login, $pw);


### PR DESCRIPTION
## What

`setProxy()`, `setReferer()` and `setRoleCredentials()` in `AbstractClient` treated the literal string `"0"` as a reset/skip sentinel:

```php
if ($proxy === '' || $proxy === '0') { unset(...); }   // setProxy / setReferer
if ($role !== '' && $role !== '0') { ... }              // setRoleCredentials
```

This is a leftover artifact of an `empty()` → explicit-comparison conversion.

## Why

These setters document the **empty-string default** as their reset value. The extra `"0"` branch was unintended: it meant a proxy/referer/role literally named `"0"` could never be set. Such values are implausible in practice, so this is **not a functional bug** — but the guard now matches the documented contract: only the empty string triggers reset/skip.

The similar guards in `CNR/IBS ResponseTranslator` are deliberately **left as-is** — there a raw response body of `"0"` is junk and normalising it to `"empty"` is correct behaviour.

## Verification

- `composer lint` clean (phpcs + PHPStan L9 + Psalm L1 + shellcheck)
- `composer rector` → "Rector is done!" (no new suggestions)
- Full suite green (287 passed, 1 pre-existing skip)

## Jira

https://centralnic.atlassian.net/browse/RSRMID-2861