### PR TITLE
refactor(response): unify Response construction via template-method hooks

### DIFF
--- a/src/CNR/Response.php
+++ b/src/CNR/Response.php
@@ -118,9 +118,33 @@ class Response implements ResponseInterface
         $this->context = $context;
         $this->command = $cmd;
         $this->requestUrl = $ph["CONNECTION_URL"] ?? "";
-        $this->raw = RT::translate($raw, $cmd, $ph);
-        $this->hash = RP::parse($this->raw);
+        $this->raw = $this->translate($raw, $cmd, $ph);
+        $this->populate();
+    }
 
+    /**
+     * Translate the raw API response into its canonical form.
+     * Brand-specific by the ResponseTranslator each subclass imports; IBS
+     * overrides this to use its own translator. $cmd is already sanitized.
+     * @param array<string, string> $cmd API command used within this request
+     * @param array{CONNECTION_URL?: string} $ph placeholder array for dynamic replacement
+     */
+    protected function translate(string $raw, array $cmd, array $ph): string
+    {
+        return RT::translate($raw, $cmd, $ph);
+    }
+
+    /**
+     * Parse the translated response into the hash and build the column/record
+     * lists from it. Parsing and column extraction are kept together because
+     * each brand's parser returns a different hash shape: CNR exposes its
+     * columns under the PROPERTY sub-array and assembles records only when
+     * properties are present, while IBS (which overrides this) uses a flat
+     * key => value map. The sanitized command is available as $this->command.
+     */
+    protected function populate(): void
+    {
+        $this->hash = RP::parse($this->raw);
         $properties = $this->hash["PROPERTY"] ?? null;
         if (is_array($properties)) {
             $colKeys = array_map("strval", array_keys($properties));

--- a/src/IBS/Response.php
+++ b/src/IBS/Response.php
@@ -19,10 +19,11 @@ use CNIC\ResponseInterface;
  * IBS Response
  *
  * Extends CNR\Response and only overrides what genuinely differs for the IBS
- * platform: the JSON-shaped response parsing (constructor), the status/code/
- * description accessors, the IBS column type, the not-supported contract
- * methods and the flat (single-page) pagination model. Every other accessor
- * and the record-cursor navigation are inherited unchanged from CNR\Response.
+ * platform: the JSON-shaped response parsing (the translate() and populate()
+ * constructor hooks), the status/code/description accessors, the IBS column
+ * type, the not-supported contract methods and the flat (single-page)
+ * pagination model. The constructor itself and every other accessor and the
+ * record-cursor navigation are inherited unchanged from CNR\Response.
  *
  * @psalm-api
  * @package CNIC\IBS
@@ -56,24 +57,28 @@ class Response extends CNRResponse implements ResponseInterface
     protected array $sensitiveFields = ["password", "transferAuthInfo"];
 
     /**
-     * Constructor
-     * @param string $raw API plain response
+     * Translate the raw API response using the IBS translator.
      * @param array<string, string> $cmd API command used within this request
-     * @param array{CONNECTION_URL?: string} $ph placeholder array to get vars in response description dynamically replaced
-     * @param array<string,mixed> $context context data for the response (for use in custom loggers etc., optional, has no impact on SDK behaviour)
+     * @param array{CONNECTION_URL?: string} $ph placeholder array for dynamic replacement
      */
-    public function __construct(string $raw, array $cmd = [], array $ph = [], array $context = [])
+    #[\Override]
+    protected function translate(string $raw, array $cmd, array $ph): string
     {
-        $cmd = $this->sanitizeCommand($cmd);
-        $this->context = $context;
-        $this->command = $cmd;
-        $this->requestUrl = $ph["CONNECTION_URL"] ?? "";
-        $this->raw = RT::translate($raw, $cmd, $ph);
-        $this->hash = RP::parse($this->raw, $cmd);
+        return RT::translate($raw, $cmd, $ph);
+    }
 
-        // IBS responses are flat key => value maps; each hash entry becomes a
-        // column. List values are kept as-is, anything else is wrapped into a
-        // single-cell list so the shared record assembly can iterate them.
+    /**
+     * Parse the translated response with the IBS parser and build the columns
+     * from it. The IBS parser needs the sanitized command (kept on
+     * $this->command by the shared constructor). IBS responses are flat
+     * key => value maps; each hash entry becomes a column, list values kept
+     * as-is and anything else wrapped into a single-cell list so the shared
+     * record assembly can iterate them.
+     */
+    #[\Override]
+    protected function populate(): void
+    {
+        $this->hash = RP::parse($this->raw, $this->command);
         $colKeys = array_map("strval", array_keys($this->hash));
         foreach ($colKeys as $k) {
             $this->addColumn($k, is_array($this->hash[$k]) && array_is_list($this->hash[$k]) ? $this->hash[$k] : [$this->hash[$k]]);


### PR DESCRIPTION
## What

`CNR\Response` and `IBS\Response` had near-identical constructors that differed only in their translator, parser, and column-extraction. This lifts the shared lifecycle into the `CNR\Response` constructor and exposes two `protected` hooks:

- **`translate()`** — swap in the brand's `ResponseTranslator`
- **`populate()`** — parse the raw response into the hash and build the column/record lists

`IBS\Response` now **drops its constructor entirely** and overrides only those two hooks.

## Why `populate()` instead of separate `parse()` + `buildColumns()` hooks

The two brands' parsers return different hash shapes (CNR: `array<string, string|array<string,list<string>>>`; IBS: mixed JSON values). A shared `parse()` hook would force the loosely-typed `$this->hash` property and lose CNR's assign-then-read type narrowing — which can't be recovered without an inline `@var`/suppress (forbidden by the project's PHPStan policy). Keeping parse + column-build together in `populate()` preserves the narrowing naturally, so the code stays PHPStan L9 / Psalm L1 clean with no annotations.

## Behaviour

Neutral — no functional change. Same lint result, same **287 passing tests / 752 assertions**.

## Verification

- `composer lint` clean (phpcs + PHPStan L9 + Psalm L1 + shellcheck)
- `composer rector` → "Rector is done!"
- Full suite green (287 passed, 1 pre-existing skip)

## Jira

https://centralnic.atlassian.net/browse/RSRMID-2862