### PR TITLE
refactor(command): memoize CommandFormatter priority map

### DIFF
--- a/src/CommandFormatter.php
+++ b/src/CommandFormatter.php
@@ -17,6 +17,17 @@ namespace CNIC;
 final class CommandFormatter
 {
     /**
+     * Memoized priority map produced by getPropertiesPriority().
+     * The map is derived from purely static data (see
+     * getPropertiesContactFieldsWithPriority()) and never depends on the
+     * command being sorted, so it is built once per process and reused across
+     * every getSortedCommand() call (each request flatten and each response
+     * getCommand()).
+     * @var array<string,int>|null
+     */
+    private static ?array $priorityCache = null;
+
+    /**
      * Get the sorted command array based on priority
      *
      * @param array<string,string> $command The command array to be sorted
@@ -133,6 +144,10 @@ final class CommandFormatter
      */
     private static function getPropertiesPriority(): array
     {
+        if (self::$priorityCache !== null) {
+            return self::$priorityCache;
+        }
+
         $propertiesWithPriority = self::getPropertiesContactFieldsWithPriority();
 
         foreach ($propertiesWithPriority["contact"]["types"] as $typePattern => $typePriority) {
@@ -141,7 +156,7 @@ final class CommandFormatter
             }
         }
 
-        return $propertiesWithPriority["properties"];
+        return self::$priorityCache = $propertiesWithPriority["properties"];
     }
 
     /**


### PR DESCRIPTION
## Summary

`CommandFormatter::getPropertiesPriority()` rebuilt its full pattern→priority map (4 contact types × 14 fields ≈ 56 generated regex patterns) on **every** call. It is invoked by `getSortedCommand()`, which runs on every `flattenCommand()` (each API request) and every `getCommand()` (each response read). The map is derived from purely static data and never depends on the command being sorted.

This caches the generated map in a `private static` property so it is built once per process and reused across all subsequent sorts.

## Notes

- Internal-only refactor — **no behaviour change**.
- Already covered by `tests/CommandFormatterTest.php`; full `composer lint` (phpcs + phpstan L9 + psalm L1) and `composer test` pass clean.

## Jira

https://centralnic.atlassian.net/browse/RSRMID-2863

🤖 Generated with [Claude Code](https://claude.com/claude-code)