### PR TITLE
refactor(session): drop unused by-reference on reuseSession()

### DIFF
--- a/src/CNR/SessionCapable.php
+++ b/src/CNR/SessionCapable.php
@@ -67,7 +67,7 @@ trait SessionCapable
      * @param array<string,mixed> $session php session object ($_SESSION)
      * @return $this
      */
-    public function reuseSession(array &$session): static
+    public function reuseSession(array $session): static
     {
         if (
             isset($session["socketcfg"]) &&


### PR DESCRIPTION
## Summary

`SessionCapable::reuseSession(array &$session)` accepted its argument **by reference** but only ever reads from it — unlike `saveSession(array &$session)`, which legitimately mutates `$session`. This drops the reference so the signature reflects `reuseSession`'s read-only contract.

## Change

- `src/CNR/SessionCapable.php`: `reuseSession(array &$session)` → `reuseSession(array $session)`

## Behaviour

No behaviour change. The sole caller passes a variable, which is still accepted by value. `phpcs` + `phpstan` (pre-commit) pass; full lint (phpcs/phpstan/psalm) clean.

## Jira

[RSRMID-2865](https://centralnic.atlassian.net/browse/RSRMID-2865)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RSRMID-2865]: https://centralnic.atlassian.net/browse/RSRMID-2865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ