### PR TITLE
build: lean dist archive + minor cleanups (RSRMID-2880/2881/2882)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,7 @@ reports export-ignore
 tests export-ignore
 docs export-ignore
 build export-ignore
+examples export-ignore
 
 # files to exclude
 .editorconfig export-ignore
@@ -19,7 +20,10 @@ build export-ignore
 .prettierrc export-ignore
 .releaserc.json export-ignore
 CLAUDE.md export-ignore
+CONTRIBUTING.md export-ignore
+HISTORY.md export-ignore
 codecov.yml export-ignore
+composer.lock export-ignore
 package.json export-ignore
 pnpm-lock.yaml export-ignore
 pnpm-workspace.yaml export-ignore

--- a/src/AbstractClient.php
+++ b/src/AbstractClient.php
@@ -118,14 +118,12 @@ abstract class AbstractClient
     /**
      * Set the default logger for this client.
      * Subclasses instantiate the appropriate Logger implementation.
-     * @return $this
      */
     abstract public function setDefaultLogger(): static;
 
     /**
      * Set custom logger to use instead of the default one.
      * Create your own class implementing \CNIC\LoggerInterface.
-     * @return $this
      */
     public function setCustomLogger(LoggerInterface $customLogger): static
     {
@@ -135,7 +133,6 @@ abstract class AbstractClient
 
     /**
      * Enable debug output to STDOUT
-     * @return $this
      */
     public function enableDebugMode(): static
     {
@@ -145,7 +142,6 @@ abstract class AbstractClient
 
     /**
      * Disable debug output
-     * @return $this
      */
     public function disableDebugMode(): static
     {
@@ -185,7 +181,6 @@ abstract class AbstractClient
      * @param string $str user agent label
      * @param string $rv user agent revision
      * @param array<string> $modules further modules to add to user agent string
-     * @return $this
      */
     public function setUserAgent(string $str, string $rv, array $modules = []): static
     {
@@ -208,7 +203,6 @@ abstract class AbstractClient
     /**
      * Set proxy to use for API communication
      * @param string $proxy proxy to use (optional, for reset)
-     * @return $this
      */
     public function setProxy(string $proxy = ""): static
     {
@@ -234,7 +228,6 @@ abstract class AbstractClient
     /**
      * Set Referer to use for API communication
      * @param string $referer Referer (optional, for reset)
-     * @return $this
      */
     public function setReferer(string $referer = ""): static
     {
@@ -268,7 +261,6 @@ abstract class AbstractClient
     /**
      * Set another connection url to be used for API communication
      * @param string $value API connection url to set
-     * @return $this
      */
     public function setURL(string $value): static
     {
@@ -279,7 +271,6 @@ abstract class AbstractClient
     /**
      * Set an API session id to be used for API communication
      * @param string $value API session id (optional, for reset)
-     * @return $this
      */
     public function setSession(string $value = ""): static
     {
@@ -291,7 +282,6 @@ abstract class AbstractClient
      * Set Credentials to be used for API communication
      * @param string $uid account name (optional, for reset)
      * @param string $pw account password (optional, for reset)
-     * @return $this
      */
     public function setCredentials(string $uid = "", string $pw = ""): static
     {
@@ -305,7 +295,6 @@ abstract class AbstractClient
      * @param string $uid account name (optional, for reset)
      * @param string $role role user id (optional, for reset)
      * @param string $pw role user password (optional, for reset)
-     * @return $this
      */
     public function setRoleCredentials(string $uid = "", string $role = "", string $pw = ""): static
     {
@@ -318,7 +307,6 @@ abstract class AbstractClient
 
     /**
      * Activate High Performance Setup
-     * @return $this
      */
     public function useHighPerformanceConnectionSetup(): static
     {
@@ -440,7 +428,6 @@ abstract class AbstractClient
 
     /**
      * Set OT&E System for API communication
-     * @return $this
      */
     public function useOTESystem(): static
     {
@@ -450,7 +437,6 @@ abstract class AbstractClient
 
     /**
      * Set LIVE System for API communication (this is the default setting)
-     * @return $this
      */
     public function useLIVESystem(): static
     {
@@ -461,7 +447,6 @@ abstract class AbstractClient
     /**
      * Set context data for the client
      * @param array<string,mixed> $context
-     * @return $this
      */
     public function setContext(array $context): static
     {

--- a/src/AbstractSocketConfig.php
+++ b/src/AbstractSocketConfig.php
@@ -56,7 +56,6 @@ abstract class AbstractSocketConfig
     /**
      * Set account name to use
      * @param string $value account name
-     * @return $this
      */
     public function setLogin(string $value): static
     {
@@ -75,7 +74,6 @@ abstract class AbstractSocketConfig
     /**
      * Set account password to use
      * @param string $value account password
-     * @return $this
      */
     public function setPassword(string $value): static
     {
@@ -94,7 +92,6 @@ abstract class AbstractSocketConfig
     /**
      * Set API Session ID to use
      * @param string $value API Session ID
-     * @return $this
      */
     public function setSession(string $value = ""): static
     {
@@ -103,7 +100,6 @@ abstract class AbstractSocketConfig
 
     /**
      * Add persistent parameter to request (request API session)
-     * @return $this
      */
     public function setPersistent(bool $value = false): static
     {

--- a/src/CNR/Client.php
+++ b/src/CNR/Client.php
@@ -33,7 +33,6 @@ class Client extends AbstractClient
 
     /**
      * Set default CNR logger
-     * @return $this
      */
     #[\Override]
     public function setDefaultLogger(): static

--- a/src/CNR/Response.php
+++ b/src/CNR/Response.php
@@ -325,7 +325,6 @@ class Response implements ResponseInterface
      * Add a column to the column list
      * @param string $key column name
      * @param string[] $data array of column data
-     * @return $this
      * @psalm-suppress MoreSpecificImplementedParamType CNR columns are always string-valued
      */
     #[\Override]
@@ -341,7 +340,6 @@ class Response implements ResponseInterface
     /**
      * Add a record to the record list
      * @param array<string,mixed> $h row hash data
-     * @return $this
      */
     #[\Override]
     public function addRecord(array $h): static
@@ -687,7 +685,6 @@ class Response implements ResponseInterface
 
     /**
      * Reset index in record list back to zero
-     * @return $this
      */
     #[\Override]
     public function rewindRecordList(): static

--- a/src/CNR/SessionCapable.php
+++ b/src/CNR/SessionCapable.php
@@ -50,7 +50,6 @@ trait SessionCapable
      * Apply session data to a PHP session object
      *
      * @param array<string,mixed> $session php session instance ($_SESSION)
-     * @return $this
      */
     public function saveSession(array &$session): static
     {
@@ -65,7 +64,6 @@ trait SessionCapable
      * Rebuild connection settings from a PHP session object
      *
      * @param array<string,mixed> $session php session object ($_SESSION)
-     * @return $this
      */
     public function reuseSession(array $session): static
     {

--- a/src/CNR/SocketConfig.php
+++ b/src/CNR/SocketConfig.php
@@ -82,7 +82,6 @@ final class SocketConfig extends AbstractSocketConfig
 
     /**
      * Add persistent parameter to request (request API session)
-     * @return $this
      */
     #[\Override]
     public function setPersistent(bool $value = false): static
@@ -112,7 +111,6 @@ final class SocketConfig extends AbstractSocketConfig
     /**
      * Set account name to use
      * @param string $value account name
-     * @return $this
      */
     #[\Override]
     public function setLogin(string $value): static
@@ -125,7 +123,6 @@ final class SocketConfig extends AbstractSocketConfig
     /**
      * Set account password to use
      * @param string $value account password
-     * @return $this
      */
     #[\Override]
     public function setPassword(string $value): static
@@ -138,7 +135,6 @@ final class SocketConfig extends AbstractSocketConfig
     /**
      * Set API Session ID to use
      * @param string $value API Session ID
-     * @return $this
      */
     #[\Override]
     public function setSession(string $value = ""): static

--- a/src/HttpTransport.php
+++ b/src/HttpTransport.php
@@ -49,7 +49,7 @@ final class HttpTransport
         curl_setopt_array($this->handle, [
             // CURLOPT_VERBOSE         => true,
             CURLOPT_URL             => $url,
-            CURLOPT_CONNECTTIMEOUT  => 30, // 30s, 300s by default
+            CURLOPT_CONNECTTIMEOUT  => 30, // 30s connect timeout (cURL defaults to 300s when this is not set explicitly)
             CURLOPT_TIMEOUT         => $timeout,
             CURLOPT_POST            => 1,
             CURLOPT_HEADER          => 0,

--- a/src/IBS/Client.php
+++ b/src/IBS/Client.php
@@ -33,7 +33,6 @@ class Client extends AbstractClient
 
     /**
      * Set default IBS logger
-     * @return $this
      */
     #[\Override]
     public function setDefaultLogger(): static

--- a/src/IBS/Response.php
+++ b/src/IBS/Response.php
@@ -191,7 +191,6 @@ class Response extends CNRResponse implements ResponseInterface
      * Add a column to the column list
      * @param string $key column name
      * @param array<array-key, mixed> $data array of column data
-     * @return $this
      */
     #[\Override]
     public function addColumn(string $key, array $data): static


### PR DESCRIPTION
## Summary

Three minor, low-risk maintenance changes grouped in one branch:

- **`build(gitattributes)`** — Align the Packagist dist archive with the documented policy (only runtime essentials ship: `src/`, `composer.json`, `LICENSE`, `README.md`). Adds missing `export-ignore` for `composer.lock` (was documented as ignored but had no line), `examples/`, `CONTRIBUTING.md`, and `HISTORY.md`. `export-ignore` affects only the dist zip — CI and `git clone` fetch the full tree.
- **`docs(transport)`** — Clarify the `CURLOPT_CONNECTTIMEOUT` comment: state the configured value in seconds and cURL's implicit 300s default when unset. No behaviour change.
- **`chore(rector)`** — Apply pending Rector modernization (remove redundant `@return $this` docblocks on setters already declaring `static`).

## Verification

- `composer lint` (phpcs + phpstan + psalm + shellcheck) — clean
- `composer rector` (dry-run) — no remaining changes
- Dist archive confirmed lean via `git check-attr export-ignore` / `git archive`

## Jira

- [RSRMID-2880](https://centralnic.atlassian.net/browse/RSRMID-2880) — .gitattributes dist-archive alignment
- [RSRMID-2881](https://centralnic.atlassian.net/browse/RSRMID-2881) — HttpTransport comment
- [RSRMID-2882](https://centralnic.atlassian.net/browse/RSRMID-2882) — Rector modernization

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[RSRMID-2880]: https://centralnic.atlassian.net/browse/RSRMID-2880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ