### PR TITLE
build(composer): align package name with Packagist (RSRMID-2886)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "centralnicgroup-opensource/rtldev-middleware-php-sdk",
+  "name": "centralnic-reseller/php-sdk",
   "type": "library",
   "description": "API connector library for the insanely fast Team Internet Backend APIs (CentralNic Reseller, Internet.bs, Moniker)",
   "keywords": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "af34bb448a8eb5d35e152e7fc8768c62",
+    "content-hash": "ce2a6ad6acd64f86e747ddceba28b204",
     "packages": [
         {
             "name": "centralnic-reseller/idn-converter",


### PR DESCRIPTION
## Summary

The `name` in `composer.json` was `centralnicgroup-opensource/rtldev-middleware-php-sdk`, which **404s on Packagist**. The package is actually published as **`centralnic-reseller/php-sdk`** (v16.0.3) — which is what the README's `composer require` already uses. This aligns the manifest with the real, install-able package name.

## Changes

- `composer.json` — `name` → `centralnic-reseller/php-sdk`
- `composer.lock` — content-hash refreshed via `composer update --lock` (no dependency version changes)

GitHub org/repo URLs (badges, `repository`, `bugs`, links in README/SECURITY) are intentionally **unchanged** — `centralnicgroup-opensource/rtldev-middleware-php-sdk` is the correct GitHub path; only the Packagist package identifier was wrong.

## Verification

- `composer validate` → `./composer.json is valid` (lock in sync)
- Diff is exactly two lines (name + content-hash)
- README `composer require centralnic-reseller/php-sdk` now matches the manifest

## Jira

- [RSRMID-2886](https://centralnic.atlassian.net/browse/RSRMID-2886)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[RSRMID-2886]: https://centralnic.atlassian.net/browse/RSRMID-2886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ