### PR TITLE
build(scripts): move demo runners from package.json to composer (RSRMID-2887)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,9 @@ composer psalm:colored # Psalm static analysis (colored output)
 composer rector        # Rector dry-run (detect modernization opportunities)
 composer rector:fix    # Rector apply (write modernized code)
 composer audit         # Check dependencies for known CVEs (Composer 2.4+)
+composer demo:cnr      # Run the CNR demo app (examples/app_CNR.php)
+composer demo:ibs      # Run the IBS demo app
+composer demo:moniker  # Run the Moniker demo app
 ```
 
 > **CI coverage:** `composer audit` is a pre-flight convenience command, not a `composer.json` script. Dependency CVE gating is already enforced on every PR by the shared `php-sdk-lint.yml` workflow (its `composer-audit` job runs `composer audit --no-dev`), which `.github/workflows/lint.yml` delegates to. There is no separate audit step to wire into this repo.

--- a/README.md
+++ b/README.md
@@ -56,16 +56,18 @@ To run the demo application, follow these steps:
 
 2. **Execute the Demo**: Once the credentials are configured, run the appropriate demo command:
 
-   Run the below npm scripts (or execute the related commands covered in package.json):
+   Run the below Composer scripts:
 
    ```sh
    # CentralNic Reseller
-   npm run test-demo-cnr
+   composer demo:cnr
    # internet.bs
-   npm run test-demo-ibs
+   composer demo:ibs
    # Moniker
-   npm run test-demo-moniker
+   composer demo:moniker
    ```
+
+   These are thin wrappers around plain PHP, so you can also run the examples directly without any tooling, e.g. `php -f examples/app_CNR.php`.
 
 3. **Update Demo Contents**:
    If you need to modify the demo contents, the relevant files are located at:

--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,28 @@
     "rector": "rector process --config .github/linters/rector.php --dry-run",
     "rector:fix": "rector process --config .github/linters/rector.php",
     "docs:serve": "php -S 0.0.0.0:8000 -t docs",
+    "demo:cnr": "@php examples/app_CNR.php",
+    "demo:ibs": "@php examples/app_IBS.php",
+    "demo:moniker": "@php examples/app_MONIKER.php",
     "generate-uml": "test -f tools/php-class-diagram/vendor/bin/php-class-diagram || (mkdir -p tools/php-class-diagram && composer require --working-dir=tools/php-class-diagram smeghead/php-class-diagram:^1.5); test -f tools/plantuml.jar || (mkdir -p tools && wget -q --timeout=30 --tries=3 https://github.com/plantuml/plantuml/releases/download/v1.2026.6/plantuml-1.2026.6.jar -O tools/plantuml.jar && echo '89948f14c93756c7a3fb7b69078ff37e8489fd79dd430c582b931e2f65358690  tools/plantuml.jar' | sha256sum -c); tools/php-class-diagram/vendor/bin/php-class-diagram --jig-diagram src/ > ./docs/uml.puml; java -jar tools/plantuml.jar ./docs/uml.puml -o uml_diagram"
+  },
+  "scripts-descriptions": {
+    "docs": "Generate API documentation with Doctum",
+    "codefix": "Auto-fix coding standard violations (phpcbf)",
+    "phpcs": "Check coding standards (PSR-12) with PHP_CodeSniffer",
+    "lint": "Run all linters (phpcs, phpstan, psalm, shellcheck)",
+    "test": "Run the PHPUnit test suite with coverage",
+    "shellcheck": "Lint shell scripts with shellcheck",
+    "phpstan": "Run PHPStan static analysis (level 9)",
+    "psalm": "Run Psalm static analysis (monochrome)",
+    "psalm:colored": "Run Psalm static analysis (colored output)",
+    "rector": "Detect modernization opportunities (Rector dry-run)",
+    "rector:fix": "Apply Rector modernization fixes",
+    "docs:serve": "Serve the generated API docs locally on port 8000",
+    "demo:cnr": "Run the CentralNic Reseller (CNR) demo application",
+    "demo:ibs": "Run the Internet.bs (IBS) demo application",
+    "demo:moniker": "Run the Moniker demo application",
+    "generate-uml": "Generate a UML class diagram (php-class-diagram + PlantUML)"
   },
   "config": {
     "allow-plugins": {

--- a/package.json
+++ b/package.json
@@ -21,10 +21,7 @@
     }
   ],
   "scripts": {
-    "prepare": "husky",
-    "test-demo-cnr": "php -f examples/app_CNR.php",
-    "test-demo-ibs": "php -f examples/app_IBS.php",
-    "test-demo-moniker": "php -f examples/app_MONIKER.php"
+    "prepare": "husky"
   },
   "keywords": [
     "cnr",


### PR DESCRIPTION
## Summary

Re-scoped from the original ticket (which proposed "npm → pnpm" wording). After discussion we decided **not** to steer users toward any JS package manager — package-manager choice is free, and the demos are pure PHP that need no Node tooling at all. So the demo runners move to **Composer scripts** and leave the Node scope entirely.

## Changes

- **composer.json** — added `demo:cnr` / `demo:ibs` / `demo:moniker` using Composer's `@php` proxy (runs with the same PHP binary Composer uses).
- **package.json** — removed the three `test-demo-*` scripts (now only `prepare`/husky remains); demos no longer depend on npm/pnpm.
- **Renamed** `test-demo-*` → `demo:*` to match the existing namespaced convention (`docs:serve`, `rector:fix`) and drop the misleading "test" prefix.
- **scripts-descriptions** — added for **all** scripts, so `composer list` / `composer run-script --list` is self-documenting.
- **README** — demo section now uses `composer demo:*`, with a raw `php -f examples/app_CNR.php` alternative (no tooling required).
- **CLAUDE.md** — scripts reference kept in sync (added the `demo:*` commands).

## Verification

- `composer validate` → valid (scripts aren't part of the lock content-hash, so no lock change)
- `composer run-script --list` shows `demo:cnr/ibs/moniker` with descriptions
- No stale `test-demo` references remain
- husky pre-commit (prettier) passed

## Note

`examples/` is `export-ignore`d (RSRMID-2880), so `demo:*` run from a clone, not from a dist install — intended, dev-only.

## Jira

- [RSRMID-2887](https://centralnic.atlassian.net/browse/RSRMID-2887)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[RSRMID-2887]: https://centralnic.atlassian.net/browse/RSRMID-2887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ