### PR TITLE
fix(ibs): status-based getCode fallback and tighten date regex anchoring (RSRMID-2888)

### DIFF
--- a/src/IBS/Response.php
+++ b/src/IBS/Response.php
@@ -87,17 +87,36 @@ class Response extends CNRResponse implements ResponseInterface
     }
 
     /**
-     * Get API response code
+     * Get API response code.
+     *
+     * IBS returns a numeric "code" on some responses even though it is not part
+     * of the public API documentation, e.g. for these requests:
+     * - /Domain/Info?domain=noexistingdomain.com&...
+     * - /unknown/path?...
+     * Two shapes occur: a top-level "code", and — since the switch to
+     * ResponseFormat=JSON — a per-product code nested under product[0].code
+     * (earlier "product_0_code", RTLDEV-16781). When present the code is returned
+     * as-is; otherwise it is derived from the status: 200 for a success, 500 for
+     * an error (see isError()).
      */
     #[\Override]
     public function getCode(): int
     {
-        foreach (["code", "product_0_code"] as $key) {
-            if (isset($this->hash[$key]) && is_numeric($this->hash[$key])) {
-                return intval($this->hash[$key]);
-            }
+        // Top-level numeric code.
+        if (isset($this->hash["code"]) && is_numeric($this->hash["code"])) {
+            return intval($this->hash["code"]);
         }
-        return 200; // default code
+        // Per-product code nested under product[0] (ResponseFormat=JSON). Cast
+        // each level to an array so a missing or scalar value degrades to
+        // "absent" instead of a type error.
+        $product = (array)($this->hash["product"] ?? []);
+        $first = (array)($product[0] ?? []);
+        if (isset($first["code"]) && is_numeric($first["code"])) {
+            return intval($first["code"]);
+        }
+        // No explicit code: map to CNR's numeric convention via status —
+        // 200 for a clear success, 500 for a clear error (see isError()).
+        return $this->isSuccess() ? 200 : 500;
     }
 
     /**

--- a/src/IBS/ResponseParser.php
+++ b/src/IBS/ResponseParser.php
@@ -51,7 +51,7 @@ final class ResponseParser
 
         // Normalize date separators (handles nested arrays)
         array_walk_recursive($result, function (mixed &$value, string $key): void {
-            if (is_string($value) && preg_match("/date|paiduntil|expiration$/i", $key)) {
+            if (is_string($value) && preg_match("/(date|paiduntil|expiration)$/i", $key)) {
                 $value = str_replace("/", "-", $value);
             }
         });

--- a/tests/IBS/ResponseNavigationTest.php
+++ b/tests/IBS/ResponseNavigationTest.php
@@ -203,10 +203,28 @@ final class ResponseNavigationTest extends TestCase
         $this->assertEquals(200, $r->getCode());
     }
 
-    public function testGetCodeFallsBackToProductCode(): void
+    public function testGetCodeFallsBackTo500ForCodelessFailure(): void
     {
-        $r = new R('{"status":"SUCCESS","product_0_code":"201"}', self::JSONCMD);
+        $r = new R('{"status":"FAILURE","message":"something went wrong"}', self::JSONCMD);
+        $this->assertEquals(500, $r->getCode());
+    }
+
+    public function testGetCodeReadsNestedProductCode(): void
+    {
+        // ResponseFormat=JSON nests products as a list; the code lives at product[0].code
+        $r = new R('{"status":"SUCCESS","product":[{"code":201}]}', self::JSONCMD);
         $this->assertEquals(201, $r->getCode());
+    }
+
+    public function testGetCodeDefaultsTo200ForJsonProductWithoutCode(): void
+    {
+        // Real Domain/Create JSON response (product present, no code) -> success => 200
+        $raw = '{"transactid":"4695e4972908b18913b9ff6a1846f5bf","status":"SUCCESS","currency":"USD",'
+            . '"price":"45.20","product":[{"price":"45.20","status":"SUCCESS","domain":"testingapitest124.com",'
+            . '"domainstatus":"REGISTRAR LOCKED","expiration":"2030\/07\/17","paiduntil":"2030\/07\/17",'
+            . '"privatewhois":"FULL","whoisprivacy":"on"}]}';
+        $r = new R($raw, self::JSONCMD);
+        $this->assertEquals(200, $r->getCode());
     }
 
     public function testGetDescriptionDefault(): void


### PR DESCRIPTION
## Summary

Two IBS hardening items from RSRMID-2888, discussed and refined before implementing.

### 1. `getCode()` — read the real code, else fall back on status (`src/IBS/Response.php`)
- Reads a **top-level** numeric `code` when present.
- Reads the **per-product** code nested under `product[0].code`. Since the switch to `ResponseFormat=JSON`, IBS returns products as a **nested array**, so the old flat `product_0_code` key no longer exists in the parsed hash (RTLDEV-16781). Example real response:
  ```json
  {"status":"SUCCESS","currency":"USD","price":"45.20","product":[{"price":"45.20","status":"SUCCESS","domain":"testingapitest124.com"}]}
  ```
- When **no** explicit code is present, derive it from the status instead of always returning `200`: **200** for a success, **500** for an error (`isError()`), mapping IBS toward CNR's numeric convention. Nested levels are `(array)`-cast so a missing/scalar value degrades to "absent" rather than a type error.

### 2. Date-normalization regex anchoring (`src/IBS/ResponseParser.php`)
`/date|paiduntil|expiration$/i` → `/(date|paiduntil|expiration)$/i` so every alternative is end-anchored. All real IBS date keys still match (`date`, `expiration`, `expirationdate`, `expirydate`, `paiduntil`, `registrationdate`, `mindate`); only mid-string false positives are removed.

## Tests
- `testGetCodeReadsNestedProductCode` — `product[0].code` → 201
- `testGetCodeDefaultsTo200ForJsonProductWithoutCode` — real Domain/Create JSON (product, no code) → 200
- `testGetCodeFallsBackTo500ForCodelessFailure` — code-less FAILURE → 500
- Existing: SUCCESS-no-code → 200, top-level `code:100005` → 100005 (IBS + MONIKER)
- No test references the obsolete flat `product_0_code` anymore.

## Verification
- `composer lint` (phpcs + phpstan L9 + psalm L1 + shellcheck) — clean
- IBS + MONIKER suites: 154 passed / 366 assertions

## Jira
- [RSRMID-2888](https://centralnic.atlassian.net/browse/RSRMID-2888)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[RSRMID-2888]: https://centralnic.atlassian.net/browse/RSRMID-2888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ