### PR TITLE
fix(response): getNextPageNumber null-contract + dedupe pagination termination (RSRMID-2884, RSRMID-2890)

### DIFF
--- a/src/CNR/Client.php
+++ b/src/CNR/Client.php
@@ -71,27 +71,24 @@ class Client extends AbstractClient
         if (array_key_exists("LAST", $mycmd)) {
             throw new \Exception("Parameter LAST in use. Please remove it to avoid issues in requestNextPage.");
         }
+        // Delegate the termination decision to the Response pagination helper so
+        // "is there a next page?" lives in one place (Response::hasNextPage())
+        // rather than being re-derived from total/limit arithmetic here. This
+        // also subsumes the former LIMIT<=0 guard: a non-positive page size makes
+        // getCurrentPageNumber() null, so hasNextPage() returns false and
+        // requestAllResponsePages() terminates instead of re-requesting the same
+        // page forever (see testRequestNextResponsePageZeroLimit).
+        if (!$rr->hasNextPage()) {
+            return null;
+        }
         $first = 0;
         if (array_key_exists("FIRST", $mycmd)) {
             $first = (int) $mycmd["FIRST"];
         }
-        $total = $rr->getRecordsTotalCount();
         $limit = $rr->getRecordsLimitation();
-        // A non-positive page size cannot advance pagination: $first would never
-        // grow, so requestAllResponsePages would loop forever re-requesting the
-        // same page. This is reachable when the caller passes LIMIT=0 (the API
-        // echoes limit=0 with a non-zero total). Treat it as "no further pages",
-        // consistent with getNumberOfPages() which also returns 0 when limit==0.
-        if ($limit <= 0) {
-            return null;
-        }
-        $first += $limit;
-        if ($first < $total) {
-            $mycmd["FIRST"] = $first;
-            $mycmd["LIMIT"] = $limit;
-            return $this->request($mycmd);
-        }
-        return null;
+        $mycmd["FIRST"] = $first + $limit;
+        $mycmd["LIMIT"] = $limit;
+        return $this->request($mycmd);
     }
 
     /**

--- a/src/CNR/Response.php
+++ b/src/CNR/Response.php
@@ -525,8 +525,10 @@ class Response implements ResponseInterface
             return null;
         }
         $page = $cp + 1;
-        $pages = $this->getNumberOfPages();
-        return ($page <= $pages ? $page : $pages);
+        if ($page > $this->getNumberOfPages()) {
+            return null;
+        }
+        return $page;
     }
 
     /**

--- a/tests/CNR/ClientTest.php
+++ b/tests/CNR/ClientTest.php
@@ -649,6 +649,29 @@ final class ClientTest extends TestCase
         $this->assertNull(self::$cl->requestNextResponsePage($r));
     }
 
+    public function testRequestNextResponsePageLastPage(): void
+    {
+        // Final page of a multi-page list (FIRST=8, LIMIT=2, TOTAL=10): the
+        // current page already holds the last rows, so there is no next page.
+        // Response::hasNextPage() returns false here, and requestNextResponsePage()
+        // must return null accordingly (termination logic is no longer duplicated).
+        RTM::addTemplate(
+            "listLastPage",
+            "[RESPONSE]\r\nPROPERTY[COUNT][0]=2\r\nPROPERTY[FIRST][0]=8\r\nPROPERTY[LAST][0]=9\r\n"
+            . "PROPERTY[LIMIT][0]=2\r\nPROPERTY[TOTAL][0]=10\r\n"
+            . "DESCRIPTION=Command completed successfully\r\nCODE=200\r\nQUEUETIME=0\r\nRUNTIME=0.286\r\nEOF\r\n"
+        );
+        $r = new R("listLastPage", [
+            "COMMAND" => "QueryDomainList",
+            "FIRST" => "8",
+            "LIMIT" => "2"
+        ]);
+        $this->assertTrue($r->isSuccess());
+        $this->assertFalse($r->hasNextPage());
+        $this->assertNull($r->getNextPageNumber());
+        $this->assertNull(self::$cl->requestNextResponsePage($r));
+    }
+
     public function testRequestAllResponsePagesOk(): void
     {
         self::$cl->setCredentials(self::$user, self::$pw)

--- a/tests/CNR/ResponseTest.php
+++ b/tests/CNR/ResponseTest.php
@@ -307,6 +307,24 @@ final class ResponseTest extends TestCase
         $this->assertEquals(2, $r->getNextPageNumber());
     }
 
+    public function testGetNextPageNumberLastPage(): void
+    {
+        // Single-page list (FIRST=0, LIMIT=10, TOTAL=2): the last page has no
+        // next page, so getNextPageNumber() must honour the documented null
+        // contract rather than clamping to the current page number.
+        RTM::addTemplate(
+            "listLastPage",
+            "[RESPONSE]\r\nPROPERTY[TOTAL][0]=2\r\nPROPERTY[FIRST][0]=0\r\n"
+            . "PROPERTY[DOMAIN][0]=example1.com\r\nPROPERTY[DOMAIN][1]=example2.com\r\n"
+            . "PROPERTY[COUNT][0]=2\r\nPROPERTY[LAST][0]=1\r\nPROPERTY[LIMIT][0]=10\r\n"
+            . "DESCRIPTION=Command completed successfully\r\nCODE=200\r\nQUEUETIME=0\r\nRUNTIME=0.023\r\nEOF\r\n"
+        );
+        $r = new R("listLastPage");
+        $this->assertEquals(1, $r->getNumberOfPages());
+        $this->assertFalse($r->hasNextPage());
+        $this->assertNull($r->getNextPageNumber());
+    }
+
     public function testGetNumberOfPages(): void
     {
         $r = new R("OK");

--- a/tests/IBS/ResponseNavigationTest.php
+++ b/tests/IBS/ResponseNavigationTest.php
@@ -104,7 +104,7 @@ final class ResponseNavigationTest extends TestCase
         $this->assertEquals(2, $pg["LAST"]); // recordsCount(3) - 1
         $this->assertEquals(3, $pg["LIMIT"]);
         $this->assertEquals(1, $pg["PAGES"]);
-        $this->assertEquals(1, $pg["NEXTPAGE"]); // clamped to the last page
+        $this->assertNull($pg["NEXTPAGE"]); // no next page on the last (only) page
         $this->assertNull($pg["PREVIOUSPAGE"]); // already on the first page
         $this->assertEquals(3, $pg["TOTAL"]);
     }


### PR DESCRIPTION
## Summary

This PR bundles two related pagination changes that ship together:

1. **RSRMID-2884** (`fix`) — `CNR\Response::getNextPageNumber()` null-contract fix.
2. **RSRMID-2890** (`refactor`) — dedupe pagination termination logic in `CNR\Client`.

### RSRMID-2884 — getNextPageNumber null-contract

`CNR\Response::getNextPageNumber()` clamped to the last page number when no next page existed, violating the `ResponseInterface` contract that documents *"null if there's no next page"*. Its siblings `hasNextPage()` and `getPreviousPageNumber()` already behave correctly at their boundaries — this method was the lone outlier.

The fix mirrors `hasNextPage()`: when `$cp + 1` exceeds the page count, return `null`. `IBS\Response` inherits this method unchanged, so the fix applies there too.

### RSRMID-2890 — dedupe pagination termination

With `getNextPageNumber()`/`hasNextPage()` now symmetric, `CNR\Client::requestNextResponsePage()` no longer needs its own `$first += $limit; $first < $total` arithmetic plus a `LIMIT<=0` guard to decide "is there a next page?". That logic now lives in one place: the method delegates the termination decision to `Response::hasNextPage()`. The former `LIMIT<=0` guard is subsumed (a non-positive page size makes `getCurrentPageNumber()` null → `hasNextPage()` false → loop terminates), and the `$first + $limit` FIRST-advance arithmetic plus the `LAST`-parameter exception are preserved unchanged. No behaviour change.

## Changes

- `src/CNR/Response.php` — return `null` when `$cp + 1 > getNumberOfPages()`. *(RSRMID-2884)*
- `src/CNR/Client.php` — `requestNextResponsePage()` delegates termination to `Response::hasNextPage()`. *(RSRMID-2890)*
- `tests/CNR/ResponseTest.php` — add `testGetNextPageNumberLastPage` (single-page case). *(RSRMID-2884)*
- `tests/IBS/ResponseNavigationTest.php` — update the pagination-metadata assertion that previously locked in the clamped value. *(RSRMID-2884)*
- `tests/CNR/ClientTest.php` — add `testRequestNextResponsePageLastPage` (final-page null return). *(RSRMID-2890)*

## Breaking change

**BREAKING CHANGE:** `getNextPageNumber()` now returns `null` on the last page instead of the current (last) page number. Callers relying on the previous clamped value must switch to `hasNextPage()` or handle the `null` sentinel.

## Verification

- Template-driven pagination tests pass (CNR + IBS).
- Full `tests/CNR/ClientTest.php`: 41 passed, 1 skipped (unrelated login test).
- `composer lint` clean (phpcs, PHPStan L9, Psalm L1).

Jira: https://centralnic.atlassian.net/browse/RSRMID-2884, https://centralnic.atlassian.net/browse/RSRMID-2890

🤖 Generated with [Claude Code](https://claude.com/claude-code)
