### PR TITLE
refactor(cnr): dedupe pagination termination via hasNextPage (RSRMID-2890)

### DIFF
--- a/src/CNR/Client.php
+++ b/src/CNR/Client.php
@@ -71,27 +71,24 @@ class Client extends AbstractClient
         if (array_key_exists("LAST", $mycmd)) {
             throw new \Exception("Parameter LAST in use. Please remove it to avoid issues in requestNextPage.");
         }
+        // Delegate the termination decision to the Response pagination helper so
+        // "is there a next page?" lives in one place (Response::hasNextPage())
+        // rather than being re-derived from total/limit arithmetic here. This
+        // also subsumes the former LIMIT<=0 guard: a non-positive page size makes
+        // getCurrentPageNumber() null, so hasNextPage() returns false and
+        // requestAllResponsePages() terminates instead of re-requesting the same
+        // page forever (see testRequestNextResponsePageZeroLimit).
+        if (!$rr->hasNextPage()) {
+            return null;
+        }
         $first = 0;
         if (array_key_exists("FIRST", $mycmd)) {
             $first = (int) $mycmd["FIRST"];
         }
-        $total = $rr->getRecordsTotalCount();
         $limit = $rr->getRecordsLimitation();
-        // A non-positive page size cannot advance pagination: $first would never
-        // grow, so requestAllResponsePages would loop forever re-requesting the
-        // same page. This is reachable when the caller passes LIMIT=0 (the API
-        // echoes limit=0 with a non-zero total). Treat it as "no further pages",
-        // consistent with getNumberOfPages() which also returns 0 when limit==0.
-        if ($limit <= 0) {
-            return null;
-        }
-        $first += $limit;
-        if ($first < $total) {
-            $mycmd["FIRST"] = $first;
-            $mycmd["LIMIT"] = $limit;
-            return $this->request($mycmd);
-        }
-        return null;
+        $mycmd["FIRST"] = $first + $limit;
+        $mycmd["LIMIT"] = $limit;
+        return $this->request($mycmd);
     }
 
     /**

--- a/tests/CNR/ClientTest.php
+++ b/tests/CNR/ClientTest.php
@@ -649,6 +649,29 @@ final class ClientTest extends TestCase
         $this->assertNull(self::$cl->requestNextResponsePage($r));
     }
 
+    public function testRequestNextResponsePageLastPage(): void
+    {
+        // Final page of a multi-page list (FIRST=8, LIMIT=2, TOTAL=10): the
+        // current page already holds the last rows, so there is no next page.
+        // Response::hasNextPage() returns false here, and requestNextResponsePage()
+        // must return null accordingly (termination logic is no longer duplicated).
+        RTM::addTemplate(
+            "listLastPage",
+            "[RESPONSE]\r\nPROPERTY[COUNT][0]=2\r\nPROPERTY[FIRST][0]=8\r\nPROPERTY[LAST][0]=9\r\n"
+            . "PROPERTY[LIMIT][0]=2\r\nPROPERTY[TOTAL][0]=10\r\n"
+            . "DESCRIPTION=Command completed successfully\r\nCODE=200\r\nQUEUETIME=0\r\nRUNTIME=0.286\r\nEOF\r\n"
+        );
+        $r = new R("listLastPage", [
+            "COMMAND" => "QueryDomainList",
+            "FIRST" => "8",
+            "LIMIT" => "2"
+        ]);
+        $this->assertTrue($r->isSuccess());
+        $this->assertFalse($r->hasNextPage());
+        $this->assertNull($r->getNextPageNumber());
+        $this->assertNull(self::$cl->requestNextResponsePage($r));
+    }
+
     public function testRequestAllResponsePagesOk(): void
     {
         self::$cl->setCredentials(self::$user, self::$pw)


### PR DESCRIPTION
## Summary

Dedupes the pagination termination logic in `CNR\Client`. `requestNextResponsePage()` re-derived the "is there a next page?" decision with its own `$first += $limit; $first < $total` arithmetic plus a `LIMIT<=0` guard — duplicating `CNR\Response::hasNextPage()`. The two implementations could drift independently.

This is an internal refactor with **no behaviour change** and no public-API change.

## Changes

- **`src/CNR/Client.php`** — `requestNextResponsePage()` now delegates the termination decision to `$rr->hasNextPage()`, so it lives in one place. The former `LIMIT<=0` guard is *subsumed*: a non-positive page size makes `getCurrentPageNumber()` return `null`, so `hasNextPage()` returns `false` and `requestAllResponsePages()` terminates instead of looping forever. The `$first + $limit` FIRST-advance arithmetic and the `LAST`-parameter exception are preserved unchanged.
- **`tests/CNR/ClientTest.php`** — added `testRequestNextResponsePageLastPage`, a template-driven (no live API) test locking the `null` return on a normal non-zero-limit final page (`FIRST=8, LIMIT=2, TOTAL=10`), a path previously only exercised indirectly via `requestAllResponsePages`.

## Equivalence

`hasNextPage()` true ⟺ `first + limit < total` when FIRST is aligned to LIMIT (always the case in CNR pagination), so the termination decision is identical. The `LIMIT=0` and `LAST`-parameter cases remain covered by `testRequestNextResponsePageZeroLimit` / `testRequestNextResponsePageLast`.

## Verification

- `composer lint` (phpcs + phpstan L9 + psalm L1): clean.
- `tests/CNR/ClientTest.php`: 41 passed, 1 skipped (unrelated login test), including all pagination cases.

## Notes

- Builds on **RSRMID-2884** (the `getNextPageNumber()` null-contract fix that makes `hasNextPage()`/`getNextPageNumber()` symmetric). This PR is therefore **based on the `RSRMID-2884/getnextpagenumber-null-contract` branch**, not `master` — intended to be rebase-merged into that branch so both land together.

Jira: https://centralnic.atlassian.net/browse/RSRMID-2890
