### PR TITLE
fix(ibs): guard ResponseParser against scalar JSON input (RSRMID-2883)

### DIFF
--- a/src/IBS/ResponseParser.php
+++ b/src/IBS/ResponseParser.php
@@ -27,8 +27,21 @@ final class ResponseParser
     {
         $isJson = $cmd === [] || (isset($cmd["ResponseFormat"]) && strtoupper($cmd["ResponseFormat"]) === "JSON");
 
-        /** @var array<string, mixed>|null $result */
+        $invalidResponse = [
+            "status" => "FAILURE",
+            "message" => "423 Invalid API response. Contact Support"
+        ];
+
+        /** @var array<string, mixed>|scalar|null $result */
         $result = $isJson ? json_decode($raw, true) : null;
+
+        // A bare valid JSON scalar (number, quoted string, boolean) decodes to a
+        // non-null, non-array value that array_walk_recursive() cannot handle.
+        // Report it as an invalid response up front rather than routing it through
+        // the plain-text parser below (which would mis-split a scalar containing "=").
+        if (is_scalar($result)) {
+            return $invalidResponse;
+        }
 
         // Plain text key=value format (templates and non-JSON responses)
         if (is_null($result)) {
@@ -43,10 +56,7 @@ final class ResponseParser
         }
 
         if (is_null($result)) {
-            return [
-                "status" => "FAILURE",
-                "message" => "423 Invalid API response. Contact Support"
-            ];
+            return $invalidResponse;
         }
 
         // Normalize date separators (handles nested arrays)

--- a/tests/IBS/ResponseTest.php
+++ b/tests/IBS/ResponseTest.php
@@ -149,6 +149,19 @@ final class ResponseTest extends TestCase
         $this->assertSame('423 Invalid API response. Contact Support', $result['message']);
     }
 
+    public function testParseScalarJsonIsInvalid(): void
+    {
+        // A bare valid JSON scalar (number, quoted string, boolean, float)
+        // decodes to a non-array value. It must not fatal in
+        // array_walk_recursive() but return the graceful invalid-response
+        // fallback, same as any other unparseable response.
+        foreach (["123", '"a string"', "true", "false", "1.5"] as $raw) {
+            $result = RP::parse($raw);
+            $this->assertSame('FAILURE', $result['status'], "raw: {$raw}");
+            $this->assertSame('423 Invalid API response. Contact Support', $result['message'], "raw: {$raw}");
+        }
+    }
+
     public function testParseForcedPlainTextWithJsonPayload(): void
     {
         // an explicit non-JSON ResponseFormat forces the plain-text path,


### PR DESCRIPTION
## Summary

`IBS\ResponseParser::parse()` fataled with a `TypeError` on valid JSON scalar input. The only guard after `json_decode($raw, true)` was `is_null($result)` before `array_walk_recursive()`. A bare valid JSON scalar (number, quoted string, boolean, float) decodes to a non-null, non-array value, so `array_walk_recursive()` — which requires an array — fataled, bypassing the intended graceful fallback (`{status: FAILURE, message: "423 Invalid API response. Contact Support"}`).

Confirmed pre-fix:

```text
parse("123")        => TypeError: array_walk_recursive(): Argument #1 must be of type array, int given
parse('"a string"') => TypeError
parse("true")       => TypeError
```

Reachable via the public static `parse()` directly. Through the full `Response` path it is usually masked by `ResponseTranslator` swapping status-less bodies for the "invalid" template — but only when that template is registered.

## Fix

Detect a scalar `json_decode()` result via `is_scalar()` and **return the invalid-response payload early**, before the plain-text parsing path. This is cleaner than routing the scalar through the plain-text parser and also more correct — a JSON scalar that happens to contain `=` (e.g. `"a=b"`) would otherwise be mis-split into bogus `key=value` data instead of reported invalid. The `FAILURE` payload is hoisted into a single `$invalidResponse` variable reused at both return points (DRY).

## Changes

- `src/IBS/ResponseParser.php` — early-return the shared `$invalidResponse` on a scalar decode result; reuse it at the existing no-data return too.
- `tests/IBS/ResponseTest.php` — add `testParseScalarJsonIsInvalid` covering integer, quoted string, boolean, and float scalar JSON inputs (previously uncovered).

## Verification

- `tests/IBS/ResponseTest.php` + `ResponseTranslatorTest.php`: 30 passed (82 assertions), including the new regression test.
- `composer lint` clean (phpcs, PHPStan L9, Psalm L1).

Jira: https://centralnic.atlassian.net/browse/RSRMID-2883

🤖 Generated with [Claude Code](https://claude.com/claude-code)
