### PR TITLE
refactor(rtm): extract AbstractResponseTemplateManager for CNR/IBS

### DIFF
--- a/src/AbstractResponseTemplateManager.php
+++ b/src/AbstractResponseTemplateManager.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * CNIC
+ * Copyright © Team Internet Group PLC
+ */
+
+namespace CNIC;
+
+/**
+ * Shared base for all registrar ResponseTemplateManager implementations.
+ *
+ * The template container plus its add/get/has/match operations are identical
+ * across brands; only the raw template strings, the generateTemplate() wire
+ * format, the two hash keys used for matching, and the concrete Response /
+ * ResponseParser classes differ. Concrete subclasses supply those via the
+ * abstract hooks below and redeclare their own $templates array.
+ *
+ * @psalm-consistent-constructor
+ * @package CNIC
+ */
+abstract class AbstractResponseTemplateManager
+{
+    /**
+     * Template container
+     * @var array<string>
+     */
+    public static array $templates = [];
+
+    /**
+     * Generate API response template string for given code and description
+     * @param string $code API response code
+     * @param string $description API response description
+     */
+    abstract public static function generateTemplate(string $code, string $description): string;
+
+    /**
+     * Get response template instance from template container.
+     * Subclasses narrow the return type to their concrete Response.
+     * @param string $id template id
+     */
+    abstract public static function getTemplate(string $id): ResponseInterface;
+
+    /**
+     * Create a brand Response instance from a template id or raw response.
+     */
+    abstract protected static function createResponse(string $raw): ResponseInterface;
+
+    /**
+     * Parse a plain API response into its hash form using the brand parser.
+     * @return array<string, mixed>
+     */
+    abstract protected static function parseResponse(string $plain): array;
+
+    /**
+     * The two response-hash keys this brand compares when matching a template
+     * (code/description equivalent, e.g. CODE/DESCRIPTION or status/message).
+     * @return array{0: string, 1: string}
+     */
+    abstract protected static function matchKeys(): array;
+
+    /**
+     * Add response template to template container
+     * @param string $id template id
+     * @param string $plain API plain response or API response code (when providing $descr)
+     * @param string|null $descr API response description (optional)
+     */
+    public static function addTemplate(string $id, string $plain, ?string $descr = null): static
+    {
+        static::$templates[$id] = is_null($descr) ? $plain : static::generateTemplate($plain, $descr);
+        return new static();
+    }
+
+    /**
+     * Return all available response templates
+     * @return array<mixed>
+     */
+    public static function getTemplates(): array
+    {
+        $tpls = [];
+        foreach (static::$templates as $key => $raw) {
+            $tpls[$key] = static::createResponse($raw);
+        }
+        return $tpls;
+    }
+
+    /**
+     * Check if given template exists in template container
+     * @param string $id template id
+     */
+    public static function hasTemplate(string $id): bool
+    {
+        return array_key_exists($id, static::$templates);
+    }
+
+    /**
+     * Check if given API response hash matches a given template by code and description
+     * @param array<string, mixed> $tpl api response hash
+     * @param string $id template id
+     */
+    public static function isTemplateMatchHash(array $tpl, string $id): bool
+    {
+        return self::matches(static::getTemplate($id)->getHash(), $tpl);
+    }
+
+    /**
+     * Check if given API plain response matches a given template by code and description
+     * @param string $plain API plain response
+     * @param string $id template id
+     */
+    public static function isTemplateMatchPlain(string $plain, string $id): bool
+    {
+        return self::matches(static::getTemplate($id)->getHash(), static::parseResponse($plain));
+    }
+
+    /**
+     * Compare two response hashes on this brand's match keys.
+     * @param array<string, mixed> $h template hash
+     * @param array<string, mixed> $tpl response hash to compare against
+     */
+    private static function matches(array $h, array $tpl): bool
+    {
+        [$codeKey, $descrKey] = static::matchKeys();
+        return (
+            ($h[$codeKey] === $tpl[$codeKey]) &&
+            ($h[$descrKey] === $tpl[$descrKey])
+        );
+    }
+}

--- a/src/CNR/ResponseTemplateManager.php
+++ b/src/CNR/ResponseTemplateManager.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace CNIC\CNR;
 
+use CNIC\AbstractResponseTemplateManager;
 use CNIC\CNR\ResponseParser as RP;
 
 /**
@@ -18,7 +19,7 @@ use CNIC\CNR\ResponseParser as RP;
  * @package CNIC\CNR
  * @final
  */
-final class ResponseTemplateManager
+final class ResponseTemplateManager extends AbstractResponseTemplateManager
 {
     /**
      * Template container
@@ -42,83 +43,48 @@ final class ResponseTemplateManager
      * @param string $code API response code
      * @param string $description API response description
      */
+    #[\Override]
     public static function generateTemplate(string $code, string $description): string
     {
         return "[RESPONSE]\r\nCODE=" . $code . "\r\nDESCRIPTION=" . $description . "\r\nEOF\r\n";
     }
 
     /**
-     * Add response template to template container
-     * @param string $id template id
-     * @param string $plain API plain response or API response code (when providing $descr)
-     * @param string|null $descr API response description (optional)
-     */
-    public static function addTemplate(string $id, string $plain, ?string $descr = null): self
-    {
-        self::$templates[$id] = is_null($descr) ? $plain : self::generateTemplate($plain, $descr);
-        return new self();
-    }
-
-    /**
      * Get response template instance from template container
      * @param string $id template id
      */
+    #[\Override]
     public static function getTemplate(string $id): Response
     {
-        if (self::hasTemplate($id)) {
-            return new Response($id);
-        }
-        return new Response("notfound");
+        return static::createResponse(static::hasTemplate($id) ? $id : "notfound");
     }
 
     /**
-     * Return all available response templates
-     * @return array<mixed>
+     * Create a CNR Response instance from a template id or raw response.
      */
-    public static function getTemplates(): array
+    #[\Override]
+    protected static function createResponse(string $raw): Response
     {
-        $tpls = [];
-        foreach (self::$templates as $key => $raw) {
-            $tpls[$key] = new Response($raw);
-        }
-        return $tpls;
+        return new Response($raw);
     }
 
     /**
-     * Check if given template exists in template container
-     * @param string $id template id
+     * Parse a plain API response into its hash form using the CNR parser.
+     * @return array<string, mixed>
      */
-    public static function hasTemplate(string $id): bool
+    #[\Override]
+    protected static function parseResponse(string $plain): array
     {
-        return array_key_exists($id, self::$templates);
+        return RP::parse($plain);
     }
 
     /**
-     * Check if given API response hash matches a given template by code and description
-     * @param array<string, mixed> $tpl api response hash
-     * @param string $id template id
+     * CNR compares templates on the CODE and DESCRIPTION hash keys.
+     * @return array{0: string, 1: string}
      */
-    public static function isTemplateMatchHash(array $tpl, string $id): bool
+    #[\Override]
+    protected static function matchKeys(): array
     {
-        $h = self::getTemplate($id)->getHash();
-        return (
-            ($h["CODE"] === $tpl["CODE"]) &&
-            ($h["DESCRIPTION"] === $tpl["DESCRIPTION"])
-        );
-    }
-
-    /**
-     * Check if given API plain response matches a given template by code and description
-     * @param string $plain API plain response
-     * @param string $id template id
-     */
-    public static function isTemplateMatchPlain(string $plain, string $id): bool
-    {
-        $h = self::getTemplate($id)->getHash();
-        $tpl = RP::parse($plain);
-        return (
-            ($h["CODE"] === $tpl["CODE"]) &&
-            ($h["DESCRIPTION"] === $tpl["DESCRIPTION"])
-        );
+        return ["CODE", "DESCRIPTION"];
     }
 }

--- a/src/IBS/ResponseTemplateManager.php
+++ b/src/IBS/ResponseTemplateManager.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace CNIC\IBS;
 
+use CNIC\AbstractResponseTemplateManager;
 use CNIC\IBS\ResponseParser as RP;
 
 /**
@@ -18,7 +19,7 @@ use CNIC\IBS\ResponseParser as RP;
  * @package CNIC\IBS
  * @final
  */
-final class ResponseTemplateManager
+final class ResponseTemplateManager extends AbstractResponseTemplateManager
 {
     /**
      * template container
@@ -39,86 +40,51 @@ final class ResponseTemplateManager
 
     /**
      * Generate API response template string for given status and description
-     * @param string $status API response code
+     * @param string $code API response status
      * @param string $description API response description
      */
-    public static function generateTemplate(string $status, string $description): string
+    #[\Override]
+    public static function generateTemplate(string $code, string $description): string
     {
-        return "status=$status\r\nmessage=$description\r\n";
-    }
-
-    /**
-     * Add response template to template container
-     * @param string $id template id
-     * @param string $plain API plain response or API response code (when providing $descr)
-     * @param string|null $descr API response description
-     */
-    public static function addTemplate(string $id, string $plain, ?string $descr = null): self
-    {
-        self::$templates[$id] = is_null($descr) ? $plain : self::generateTemplate($plain, $descr);
-        return new self();
+        return "status=$code\r\nmessage=$description\r\n";
     }
 
     /**
      * Get response template instance from template container
      * @param string $id template id
      */
+    #[\Override]
     public static function getTemplate(string $id): Response
     {
-        if (self::hasTemplate($id)) {
-            return new Response($id);
-        }
-        return new Response("notfound");
+        return static::createResponse(static::hasTemplate($id) ? $id : "notfound");
     }
 
     /**
-     * Return all available response templates
-     * @return array<mixed>
+     * Create an IBS Response instance from a template id or raw response.
      */
-    public static function getTemplates(): array
+    #[\Override]
+    protected static function createResponse(string $raw): Response
     {
-        $tpls = [];
-        foreach (self::$templates as $key => $raw) {
-            $tpls[$key] = new Response($raw);
-        }
-        return $tpls;
+        return new Response($raw);
     }
 
     /**
-     * Check if given template exists in template container
-     * @param string $id template id
+     * Parse a plain API response into its hash form using the IBS parser.
+     * @return array<string, mixed>
      */
-    public static function hasTemplate(string $id): bool
+    #[\Override]
+    protected static function parseResponse(string $plain): array
     {
-        return array_key_exists($id, self::$templates);
+        return RP::parse($plain);
     }
 
     /**
-     * Check if given API response hash matches a given template by code and description
-     * @param array<string, mixed> $tpl api response hash
-     * @param string $id template id
+     * IBS compares templates on the status and message hash keys.
+     * @return array{0: string, 1: string}
      */
-    public static function isTemplateMatchHash(array $tpl, string $id): bool
+    #[\Override]
+    protected static function matchKeys(): array
     {
-        $h = self::getTemplate($id)->getHash();
-        return (
-            ($h["status"] === $tpl["status"]) &&
-            ($h["message"] === $tpl["message"])
-        );
-    }
-
-    /**
-     * Check if given API plain response matches a given template by code and description
-     * @param string $plain API plain response
-     * @param string $id template id
-     */
-    public static function isTemplateMatchPlain(string $plain, string $id): bool
-    {
-        $h = self::getTemplate($id)->getHash();
-        $tpl = RP::parse($plain);
-        return (
-            ($h["status"] === $tpl["status"]) &&
-            ($h["message"] === $tpl["message"])
-        );
+        return ["status", "message"];
     }
 }


### PR DESCRIPTION
## Summary

Removes the ~95% byte-identical duplication between `CNR\ResponseTemplateManager` and `IBS\ResponseTemplateManager` by extracting a shared `CNIC\AbstractResponseTemplateManager`.

The abstract base holds the previously-duplicated operations — `addTemplate`, `getTemplates`, `hasTemplate`, `isTemplateMatchHash`, `isTemplateMatchPlain` (plus a private `matches()` helper). Each brand subclass now supplies only what actually differs:

- `$templates` (redeclared per brand)
- `generateTemplate()` — wire format
- `matchKeys()` — the two compared hash keys (`CODE`/`DESCRIPTION` vs `status`/`message`)
- `parseResponse()` / `createResponse()` — brand parser & concrete `Response`
- a one-line `getTemplate()` narrowing the return to the concrete `Response`

## Design notes

- Static methods use **late static binding** (`static::$templates`, `static::generateTemplate()`, `new static()`) so each subclass's data/hooks resolve correctly.
- **No class-level generic.** A `@template`-generic base can't preserve its type parameter through `new static()` under PHPStan L9 (only disallowed suppressions would fix it). Each subclass keeps a tiny concrete `getTemplate()` instead — required anyway because the IBS test calls `->getStatus()`, which is not on `ResponseInterface`, so a widened return would break static analysis of the tests.
- **No behaviour change**: public API, external `RTM::$templates` access (used by `ResponseTranslator`), and fluent chaining are preserved. Non-releasing `refactor`.

## Verification

- `composer lint` — clean (phpcs, PHPStan L9, Psalm L1, shellcheck)
- `composer test` — passing; CNR/IBS RTM subclasses at 100% coverage

## Jira

https://centralnic.atlassian.net/browse/RSRMID-2892

🤖 Generated with [Claude Code](https://claude.com/claude-code)