### PR TITLE
refactor(rtm): extract AbstractResponseTranslator; unify placeholder stripping

### DIFF
--- a/src/AbstractResponseTranslator.php
+++ b/src/AbstractResponseTranslator.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * CNIC
+ * Copyright © Team Internet Group PLC
+ */
+
+namespace CNIC;
+
+/**
+ * Shared base for all registrar ResponseTranslator implementations.
+ *
+ * The translate()/findMatch() pipeline is identical across brands: empty->"empty",
+ * "httperror|" splitting, static-template lookup with {HTTPERROR} injection,
+ * invalid-template fallback, the two description-map rewrite loops, findMatch(),
+ * and placeholder replacement. Only a few narrow points differ, supplied by the
+ * abstract hooks below:
+ *   - the static template container (templates())
+ *   - the two description rewrite maps (descriptionRegexMap()/descriptionRawPatternMap())
+ *   - the response field carrying the human-readable text (fieldName():
+ *     "description" for CNR, "message" for IBS)
+ *   - the "missing/empty required field" check that triggers the invalid fallback
+ *     (hasMissingRequiredFields(): CODE/DESCRIPTION for CNR, status for IBS)
+ *
+ * Placeholder stripping is deliberately unified on the per-field, per-token callback
+ * (formerly CNR-only): unknown {UPPER} tokens are removed only inside the
+ * human-readable field, leaving {UPPER} content in other data fields untouched. The
+ * former IBS behaviour stripped such tokens globally across the whole response, which
+ * risked corrupting legitimate data fields — replacePlaceholders() below is the single
+ * correct behaviour for both brands. (Ref: RSRMID-2893.)
+ *
+ * @package CNIC
+ */
+abstract class AbstractResponseTranslator
+{
+    /**
+     * The brand's static template container (id => raw template string).
+     * @return array<string>
+     */
+    abstract protected static function templates(): array;
+
+    /**
+     * plain-string description keys for translation; keys are preg_quote'd before matching
+     * @return array<string, string>
+     */
+    abstract protected static function descriptionRegexMap(): array;
+
+    /**
+     * raw regex pattern keys for translation; keys are used as-is (not preg_quote'd)
+     * @return array<string, string>
+     */
+    abstract protected static function descriptionRawPatternMap(): array;
+
+    /**
+     * Name of the response field carrying the human-readable text
+     * ("description" for CNR, "message" for IBS).
+     */
+    abstract protected static function fieldName(): string;
+
+    /**
+     * Whether the raw response is missing or has an empty required field
+     * (CNR: CODE/DESCRIPTION, IBS: status) and should therefore fall back to the
+     * "invalid" template.
+     * @param string $raw API raw response (already normalised)
+     */
+    abstract protected static function hasMissingRequiredFields(string $raw): bool;
+
+    /**
+     * translate a raw api response
+     * @param string $raw API raw response
+     * @param array<string, string> $cmd requested API command
+     * @param array{CONNECTION_URL?: string} $ph list of place holder vars
+     */
+    public static function translate(string $raw, array $cmd, array $ph = []): string
+    {
+        $newraw = $raw === '' || $raw === '0' ? "empty" : $raw;
+        // Hint: Empty API Response (replace {CONNECTION_URL} later)
+
+        // curl error handling
+        $httperror = "";
+        $isHTTPError = substr($newraw, 0, 10) === "httperror|";
+        if ($isHTTPError) {
+            $parts = explode("|", $newraw, 2);
+            $newraw = $parts[0];
+            $httperror = $parts[1] ?? "";
+        }
+
+        $templates = static::templates();
+
+        // Explicit call for a static template
+        if (array_key_exists($newraw, $templates)) {
+            // don't use getTemplate as it leads to endless loop as of again
+            // creating a response instance
+            $newraw = $templates[$newraw];
+            if ($isHTTPError && strlen($httperror)) {
+                $newraw = preg_replace("/\{HTTPERROR\}/", " (" . $httperror . ")", $newraw) ?? $newraw;
+            }
+        }
+
+        // Missing or empty required field(s) in API response
+        if (static::hasMissingRequiredFields($newraw) && array_key_exists("invalid", $templates)) {
+            $newraw = $templates["invalid"];
+        }
+
+        // generic API response description rewrite
+        $data = false;
+        foreach (static::descriptionRegexMap() as $regex => $val) {
+            $data = self::findMatch(preg_quote($regex, "/"), $newraw, $val, $cmd);
+            if ($data) {
+                break;
+            }
+        }
+        if (!$data) {
+            foreach (static::descriptionRawPatternMap() as $pattern => $val) {
+                $data = self::findMatch($pattern, $newraw, $val, $cmd);
+                if ($data) {
+                    break;
+                }
+            }
+        }
+
+        return static::replacePlaceholders($newraw, $ph);
+    }
+
+    /**
+     * Finds a match in the given text and performs replacements based on patterns and placeholders.
+     *
+     * This function searches for a specified regular expression pattern in the provided text and
+     * performs replacements based on the matched pattern, command data, and placeholder values.
+     *
+     * @param string $regex The regular expression pattern to search for.
+     * @param string $newraw The input text where the match will be searched for and replacements applied.
+     * @param string $val The value to be used in replacement if a match is found.
+     * @param array<string, string> $cmd The command data containing replacements, if applicable.
+     */
+    private static function findMatch(string $regex, string &$newraw, string $val, array $cmd): bool
+    {
+        // match the response for given description
+        // NOTE: we match if the description starts with the given description
+        // it would also match if it is followed by additional text
+        $field = static::fieldName();
+        $qregex = "/" . $field . "\s*=\s*" . $regex . "([^\\r\\n]+)?/i";
+        $return = false;
+
+        if (preg_match($qregex, $newraw)) {
+            // If "COMMAND" exists in $cmd, replace "{COMMAND}" in $val
+            if (isset($cmd["COMMAND"])) {
+                $val = str_replace("{COMMAND}", $cmd["COMMAND"], $val);
+            }
+
+            // If $newraw matches $qregex, replace with "<field>=" . $val
+            $tmp = preg_replace($qregex, $field . "=" . $val, $newraw);
+            if ($tmp !== null && $tmp !== $newraw) {
+                $newraw = $tmp;
+                $return = true;
+            }
+        }
+
+        return $return;
+    }
+
+    /**
+     * Replace known placeholders in the human-readable field while preserving
+     * literal brace content and unknown-token content in other fields.
+     *
+     * Operates line-by-line on the brand's field (see fieldName()): provided
+     * placeholders are substituted, unknown {UPPER} tokens are stripped, and any
+     * other brace content (e.g. lowercase %{i} in SPF records) is left untouched.
+     *
+     * @param string $raw input response
+     * @param array{CONNECTION_URL?: string} $ph placeholder key-value pairs
+     */
+    protected static function replacePlaceholders(string $raw, array $ph): string
+    {
+        $field = static::fieldName();
+        $tmp = preg_replace_callback(
+            '/^(' . $field . '\s*=\s*)(.*)$/im',
+            static function ($matches) use ($ph) {
+                $description = $matches[2];
+
+                if (strpos($description, '{') === false) {
+                    return $matches[0];
+                }
+
+                $description = preg_replace_callback(
+                    '/\{([^}]+)\}/',
+                    static function ($tokenMatches) use ($ph) {
+                        $token = $tokenMatches[1];
+
+                        if (array_key_exists($token, $ph)) {
+                            return $ph[$token];
+                        }
+
+                        if (preg_match('/^[A-Z][A-Z0-9_]*$/', $token) === 1) {
+                            return '';
+                        }
+
+                        return $tokenMatches[0];
+                    },
+                    $description
+                );
+
+                return $matches[1] . ($description ?? $matches[2]);
+            },
+            $raw
+        );
+
+        return $tmp ?? $raw;
+    }
+}

--- a/src/CNR/ResponseTranslator.php
+++ b/src/CNR/ResponseTranslator.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace CNIC\CNR;
 
+use CNIC\AbstractResponseTranslator;
 use CNIC\CNR\ResponseTemplateManager as RTM;
 
 /**
@@ -16,7 +17,7 @@ use CNIC\CNR\ResponseTemplateManager as RTM;
  *
  * @package CNIC\CNR
  */
-final class ResponseTranslator
+final class ResponseTranslator extends AbstractResponseTranslator
 {
     /**
      * plain-string description keys for translation; keys are preg_quote'd before matching
@@ -43,143 +44,51 @@ final class ResponseTranslator
     ];
 
     /**
-     * translate a raw api response
-     * @param string $raw API raw response
-     * @param array<string, string> $cmd requested API command
-     * @param array{CONNECTION_URL?: string} $ph list of place holder vars
+     * The CNR static template container.
+     * @return array<string>
      */
-    public static function translate(string $raw, array $cmd, array $ph = []): string
+    #[\Override]
+    protected static function templates(): array
     {
-        $newraw = $raw === '' || $raw === '0' ? "empty" : $raw;
-        // Hint: Empty API Response (replace {CONNECTION_URL} later)
-
-        // curl error handling
-        $httperror = "";
-        $isHTTPError = substr($newraw, 0, 10) === "httperror|";
-        if ($isHTTPError) {
-            $parts = explode("|", $newraw, 2);
-            $newraw = $parts[0];
-            $httperror = $parts[1] ?? "";
-        }
-
-        // Explicit call for a static template
-        if (RTM::hasTemplate($newraw)) {
-            // don't use getTemplate as it leads to endless loop as of again
-            // creating a response instance
-            $newraw = RTM::$templates[$newraw];
-            if ($isHTTPError && strlen($httperror)) {
-                $newraw = preg_replace("/\{HTTPERROR\}/", " (" . $httperror . ")", $newraw) ?? $newraw;
-            }
-        }
-
-        // Missing CODE or DESCRIPTION in API Response
-        if (
-            (
-                !preg_match("/description[\s]*=/i", $newraw) // missing description
-                || preg_match("/description[\s]*=\r\n/i", $newraw) // empty description
-                || !preg_match("/code[\s]*=/i", $newraw) // missing code
-            )
-            && RTM::hasTemplate("invalid")
-        ) {
-            $newraw = RTM::$templates["invalid"];
-        }
-
-        // generic API response description rewrite
-        $data = false;
-        foreach (self::$descriptionRegexMap as $regex => $val) {
-            $data = self::findMatch(preg_quote($regex, "/"), $newraw, $val, $cmd);
-            if ($data) {
-                break;
-            }
-        }
-        if (!$data) {
-            foreach (self::$descriptionRawPatternMap as $pattern => $val) {
-                $data = self::findMatch($pattern, $newraw, $val, $cmd);
-                if ($data) {
-                    break;
-                }
-            }
-        }
-
-        return self::replacePlaceholders($newraw, $ph);
+        return RTM::$templates;
     }
 
     /**
-     * Finds a match in the given text and performs replacements based on patterns and placeholders.
-     *
-     * This function searches for a specified regular expression pattern in the provided text and
-     * performs replacements based on the matched pattern, command data, and placeholder values.
-     *
-     * @param string $regex The regular expression pattern to search for.
-     * @param string $newraw The input text where the match will be searched for and replacements applied.
-     * @param string $val The value to be used in replacement if a match is found.
-     * @param array<string, string> $cmd The command data containing replacements, if applicable.
+     * @return array<string, string>
      */
-    private static function findMatch(string $regex, string &$newraw, string $val, array $cmd): bool
+    #[\Override]
+    protected static function descriptionRegexMap(): array
     {
-        // match the response for given description
-        // NOTE: we match if the description starts with the given description
-        // it would also match if it is followed by additional text
-        $qregex = "/description\s*=\s*" . $regex . "([^\\r\\n]+)?/i";
-        $return = false;
-
-        if (preg_match($qregex, $newraw)) {
-            // If "COMMAND" exists in $cmd, replace "{COMMAND}" in $val
-            if (isset($cmd["COMMAND"])) {
-                $val = str_replace("{COMMAND}", $cmd["COMMAND"], $val);
-            }
-
-            // If $newraw matches $qregex, replace with "description=" . $val
-            $tmp = preg_replace($qregex, "description=" . $val, $newraw);
-            if ($tmp !== null && $tmp !== $newraw) {
-                $newraw = $tmp;
-                $return = true;
-            }
-        }
-
-        return $return;
+        return self::$descriptionRegexMap;
     }
 
     /**
-     * Replace known placeholders in DESCRIPTION while preserving literal brace content.
-     *
-     * @param string $raw input response
-     * @param array{CONNECTION_URL?: string} $ph placeholder key-value pairs
+     * @return array<string, string>
      */
-    protected static function replacePlaceholders(string $raw, array $ph): string
+    #[\Override]
+    protected static function descriptionRawPatternMap(): array
     {
-        $tmp = preg_replace_callback(
-            '/^(description\s*=\s*)(.*)$/im',
-            static function ($matches) use ($ph) {
-                $description = $matches[2];
+        return self::$descriptionRawPatternMap;
+    }
 
-                if (strpos($description, '{') === false) {
-                    return $matches[0];
-                }
+    /**
+     * CNR carries the human-readable text in the DESCRIPTION field.
+     */
+    #[\Override]
+    protected static function fieldName(): string
+    {
+        return "description";
+    }
 
-                $description = preg_replace_callback(
-                    '/\{([^}]+)\}/',
-                    static function ($tokenMatches) use ($ph) {
-                        $token = $tokenMatches[1];
-
-                        if (array_key_exists($token, $ph)) {
-                            return $ph[$token];
-                        }
-
-                        if (preg_match('/^[A-Z][A-Z0-9_]*$/', $token) === 1) {
-                            return '';
-                        }
-
-                        return $tokenMatches[0];
-                    },
-                    $description
-                );
-
-                return $matches[1] . ($description ?? $matches[2]);
-            },
-            $raw
-        );
-
-        return $tmp ?? $raw;
+    /**
+     * CNR falls back to the "invalid" template when CODE or DESCRIPTION is
+     * missing, or DESCRIPTION is present but empty.
+     */
+    #[\Override]
+    protected static function hasMissingRequiredFields(string $raw): bool
+    {
+        return !preg_match("/description[\s]*=/i", $raw) // missing description
+            || preg_match("/description[\s]*=\r\n/i", $raw) === 1 // empty description
+            || !preg_match("/code[\s]*=/i", $raw); // missing code
     }
 }

--- a/src/IBS/ResponseTranslator.php
+++ b/src/IBS/ResponseTranslator.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace CNIC\IBS;
 
+use CNIC\AbstractResponseTranslator;
 use CNIC\IBS\ResponseTemplateManager as RTM;
 
 /**
@@ -16,13 +17,12 @@ use CNIC\IBS\ResponseTemplateManager as RTM;
  *
  * @package CNIC\IBS
  */
-final class ResponseTranslator
+final class ResponseTranslator extends AbstractResponseTranslator
 {
     // NOTE: IBS has no brand-specific message rewrites yet, so both maps below are
-    // intentionally empty. While they stay empty, translate() returns via the early
-    // exit in the "$descriptionRegexMap === [] && $descriptionRawPatternMap === []"
-    // branch and findMatch() is never reached — it is kept for structural parity with
-    // CNR\ResponseTranslator and becomes live as soon as an entry is added here.
+    // intentionally empty. While they stay empty the two rewrite loops in the shared
+    // translate() pipeline iterate over nothing and findMatch() is never reached — the
+    // maps become live as soon as an entry is added here.
 
     /**
      * plain-string description keys for translation; keys are preg_quote'd before matching
@@ -37,117 +37,52 @@ final class ResponseTranslator
     private static array $descriptionRawPatternMap = [];
 
     /**
-     * translate a raw api response
-     * @param string $raw API raw response
-     * @param array<string, string> $cmd requested API command
-     * @param array{CONNECTION_URL?: string} $ph list of place holder vars
-     * @psalm-suppress UnusedParam $cmd kept for API consistency with CNR\ResponseTranslator
+     * The IBS static template container.
+     * @return array<string>
      */
-    public static function translate(string $raw, array $cmd, array $ph = []): string
+    #[\Override]
+    protected static function templates(): array
     {
-        $newraw = $raw === '' || $raw === '0' ? "empty" : $raw;
-        // Hint: Empty API Response (replace {CONNECTION_URL} later)
-
-        // curl error handling
-        $httperror = "";
-        $isHTTPError = substr($newraw, 0, 10) === "httperror|";
-        if ($isHTTPError) {
-            $parts = explode("|", $newraw, 2);
-            $newraw = $parts[0];
-            $httperror = $parts[1] ?? "";
-        }
-
-        // Explicit call for a static template
-        if (RTM::hasTemplate($newraw)) {
-            // don't use getTemplate as it leads to endless loop as of again
-            // creating a response instance
-            $newraw = RTM::$templates[$newraw];
-            if ($isHTTPError && strlen($httperror)) {
-                $newraw = preg_replace("/\{HTTPERROR\}/", " (" . $httperror . ")", $newraw) ?? $newraw;
-            }
-        }
-
-        // Missing or empty status in API Response
-        if (
-            (
-                (!preg_match("/\"status\":/i", $newraw) && !preg_match("/^status=/im", $newraw)) // missing status
-                || preg_match("/\"status\":\s*\"\"/i", $newraw) // empty status (JSON)
-                || preg_match("/^status=\r?$/im", $newraw) // empty status (plain text)
-                // do not check for message as it is optional in success cases
-            )
-            && RTM::hasTemplate("invalid")
-        ) {
-            $newraw = RTM::$templates["invalid"];
-        }
-
-        if (self::$descriptionRegexMap === [] && self::$descriptionRawPatternMap === []) {
-            return self::replacePlaceholders($newraw, $ph);
-        }
-
-        // generic API response description rewrite
-        $data = false;
-        foreach (self::$descriptionRegexMap as $regex => $val) {
-            $data = self::findMatch(preg_quote($regex, "/"), $newraw, $val);
-            if ($data) {
-                break;
-            }
-        }
-        if (!$data) {
-            foreach (self::$descriptionRawPatternMap as $pattern => $val) {
-                $data = self::findMatch($pattern, $newraw, $val);
-                if ($data) {
-                    break;
-                }
-            }
-        }
-
-        return self::replacePlaceholders($newraw, $ph);
+        return RTM::$templates;
     }
 
     /**
-     * Finds a match in the given text and performs replacements based on patterns and placeholders.
-     *
-     * This function searches for a specified regular expression pattern in the provided text and
-     * performs replacements based on the matched pattern, command data, and placeholder values.
-     *
-     * @param string $regex The regular expression pattern to search for.
-     * @param string $newraw The input text where the match will be searched for and replacements applied.
-     * @param string $val The value to be used in replacement if a match is found.
-     * @return bool Returns true if replacements were performed, false otherwise.
+     * @return array<string, string>
      */
-    private static function findMatch(string $regex, string &$newraw, string $val): bool
+    #[\Override]
+    protected static function descriptionRegexMap(): array
     {
-        // match the response for given description
-        // NOTE: we match if the description starts with the given description
-        // it would also match if it is followed by additional text
-        $qregex = "/message\s*=\s*" . $regex . "([^\\r\\n]+)?/i";
-        $return = false;
-
-        if (preg_match($qregex, $newraw)) {
-            // If $newraw matches $qregex, replace with "message=" . $val
-            $tmp = preg_replace($qregex, "message=" . $val, $newraw);
-            if ($tmp !== null && strcmp($tmp, $newraw) !== 0) {
-                $newraw = $tmp;
-                $return = true;
-            }
-        }
-
-        return $return;
+        return self::$descriptionRegexMap;
     }
 
     /**
-     * Replace placeholder vars like {CONNECTION_URL} in a string
-     * @param string $raw input string
-     * @param array{CONNECTION_URL?: string} $ph placeholder key-value pairs
+     * @return array<string, string>
      */
-    protected static function replacePlaceholders(string $raw, array $ph): string
+    #[\Override]
+    protected static function descriptionRawPatternMap(): array
     {
-        if (preg_match("/\{[A-Z][A-Z0-9_]*\}/", $raw)) {
-            foreach ($ph as $key => $val) {
-                $raw = preg_replace("/\{" . preg_quote($key, "/") . "\}/", $val, $raw) ?? $raw;
-            }
-            $raw = preg_replace("/\s?\{[A-Z][A-Z0-9_]*\}/", "", $raw) ?? $raw;
-        }
-        return $raw;
+        return self::$descriptionRawPatternMap;
+    }
+
+    /**
+     * IBS carries the human-readable text in the message field.
+     */
+    #[\Override]
+    protected static function fieldName(): string
+    {
+        return "message";
+    }
+
+    /**
+     * IBS falls back to the "invalid" template when status is missing (JSON or
+     * plain) or present but empty. message is optional in success cases and is
+     * deliberately not checked.
+     */
+    #[\Override]
+    protected static function hasMissingRequiredFields(string $raw): bool
+    {
+        return (!preg_match("/\"status\":/i", $raw) && !preg_match("/^status=/im", $raw)) // missing status
+            || preg_match("/\"status\":\s*\"\"/i", $raw) === 1 // empty status (JSON)
+            || preg_match("/^status=\r?$/im", $raw) === 1; // empty status (plain text)
     }
 }

--- a/tests/IBS/ResponseTranslatorTest.php
+++ b/tests/IBS/ResponseTranslatorTest.php
@@ -37,6 +37,27 @@ final class ResponseTranslatorTest extends TestCase
     }
 
     /**
+     * Test that unknown uppercase {TOKEN} markers are stripped only inside the
+     * message field, leaving such tokens in other data fields untouched.
+     *
+     * Guards the unified placeholder strategy (RSRMID-2893): the former IBS
+     * behaviour stripped {UPPER} tokens globally across the whole response, which
+     * would have removed the token from the data field below.
+     */
+    public function testUppercaseTokenStrippedOnlyInMessageField(): void
+    {
+        $raw = RT::translate(
+            "status=SUCCESS\r\nmessage=see {UNKNOWN}\r\nspf={UNKNOWN}\r\n",
+            []
+        );
+
+        // stripped inside the message field
+        $this->assertStringContainsString("message=see \r\n", $raw);
+        // preserved in the data field
+        $this->assertStringContainsString("spf={UNKNOWN}", $raw);
+    }
+
+    /**
      * Test that an empty raw response maps to the "empty" template
      */
     public function testEmptyResponseMapsToEmptyTemplate(): void


### PR DESCRIPTION
## Summary

Extracts the shared CNR/IBS `ResponseTranslator` pipeline into a new `CNIC\AbstractResponseTranslator`, mirroring the `AbstractResponseTemplateManager` extraction (RSRMID-2892). Also resolves the latent placeholder-stripping inconsistency called out in the ticket.

Jira: [RSRMID-2893](https://centralnic.atlassian.net/browse/RSRMID-2893)

## What changed

- **New `src/AbstractResponseTranslator.php`** holds the whole shared pipeline: `empty->"empty"`, `httperror|` splitting, static-template lookup with `{HTTPERROR}` injection, invalid-template fallback, the two description-map rewrite loops, `findMatch()`, and `replacePlaceholders()`.
- **Brand hooks** supply the narrow differences:
  - `templates()` — the brand's static template container
  - `descriptionRegexMap()` / `descriptionRawPatternMap()` — the rewrite maps
  - `fieldName()` — the human-readable field (`description` for CNR, `message` for IBS)
  - `hasMissingRequiredFields()` — the invalid-fallback trigger (`CODE`/`DESCRIPTION` for CNR, `status` for IBS)
- **CNR/IBS `ResponseTranslator`** now extend the abstract and keep only their maps + hooks.

## Placeholder-stripping decision

CNR stripped unknown `{UPPER}` tokens **per-field** via a callback (only inside `DESCRIPTION`); IBS stripped them **globally** across the whole response. Unified on the CNR per-field callback as the single correct behaviour — global stripping risked removing legitimate `{UPPER}` content from data fields. `replacePlaceholders()` is now shared and parameterised by `fieldName()`. A new IBS test locks in that a `{TOKEN}` in a non-message data field is preserved.

`{COMMAND}`/`$cmd` handling folds into the shared `findMatch()` (harmless for IBS, whose maps are empty), removing the former IBS `UnusedParam` suppression.

## Verification

- `composer test` — all tests pass (added 1 IBS test)
- `composer lint` — phpcs + phpstan (L9) + psalm (L1) all clean

Non-releasing refactor; no behaviour change for existing CNR/IBS tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RSRMID-2893]: https://centralnic.atlassian.net/browse/RSRMID-2893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ