### PR TITLE
feat(factory): return shared AbstractClient instead of 3-way union

### DIFF
--- a/examples/app_CNR.php
+++ b/examples/app_CNR.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use CNIC\ClientFactory;
+use CNIC\CNR\SessionClient;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -27,6 +28,10 @@ print_r($r->getHash());
 // --- SESSION BASED API COMMUNICATION ---
 echo "--- SESSION-BASED API COMMUNICATION ----\n";
 $cl = ClientFactory::getClient("CNR"); // fka RRPproxy
+// The factory returns the shared CNIC\AbstractClient contract. Session handling
+// (login/logout/saveSession) is CNR-specific, so narrow to the concrete
+// SessionClient before using it — the SDK guarantees the CNR arm is one.
+assert($cl instanceof SessionClient);
 $cl->useOTESystem() //LIVE System would be used otherwise by default
     ->setCredentials($user, $password);
 $r = $cl->login();

--- a/examples/app_IBS.php
+++ b/examples/app_IBS.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use CNIC\ClientFactory;
+use CNIC\IBS\Client;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -17,6 +18,10 @@ if ($user === false || $password === false) {
 // --- SESSIONLESS API COMMUNICATION ---
 echo "--- SESSION-LESS API COMMUNICATION ----\n\n";
 $cl = ClientFactory::getClient("IBS");
+// The factory returns the shared CNIC\AbstractClient contract. The per-request
+// endpoint path (request($cmd, $path)) is IBS/Moniker-specific, so narrow to
+// the concrete Client before using it — the SDK guarantees the IBS arm is one.
+assert($cl instanceof Client);
 $cl->useOTESystem()//LIVE System would be used otherwise by default
    //->setRemoteIPAddress("1.2.3.4") // provide ip address used for active ip filter
    ->setCredentials($user, $password)

--- a/examples/app_MONIKER.php
+++ b/examples/app_MONIKER.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use CNIC\ClientFactory;
+use CNIC\MONIKER\Client;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -17,6 +18,10 @@ if ($user === false || $password === false) {
 // --- SESSIONLESS API COMMUNICATION ---
 echo "--- SESSION-LESS API COMMUNICATION ----\n\n";
 $cl = ClientFactory::getClient("MONIKER");
+// The factory returns the shared CNIC\AbstractClient contract. The per-request
+// endpoint path (request($cmd, $path)) is IBS/Moniker-specific, so narrow to
+// the concrete Client before using it — the SDK guarantees the Moniker arm is one.
+assert($cl instanceof Client);
 $cl->useOTESystem()//LIVE System would be used otherwise by default
    //->setRemoteIPAddress("1.2.3.4") // provide ip address used for active ip filter
    ->setCredentials($user, $password)

--- a/examples/bulk_app_CNR.php
+++ b/examples/bulk_app_CNR.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use CNIC\ClientFactory;
+use CNIC\CNR\SessionClient;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -50,6 +51,9 @@ echo "Time: $end1 seconds\n";
 echo "--- SESSION-BASED API COMMUNICATION ----\n";
 
 $cl = ClientFactory::getClient("CNR"); // fka RRPproxy
+// Session handling (login/logout) is CNR-specific; narrow the shared
+// CNIC\AbstractClient contract to the concrete SessionClient before using it.
+assert($cl instanceof SessionClient);
 $cl->useOTESystem() //LIVE System would be used otherwise by default
     ->setRoleCredentials($user, $role, $rolepassword);
 $r = $cl->login();

--- a/src/ClientFactory.php
+++ b/src/ClientFactory.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace CNIC;
 
+use CNIC\AbstractClient;
 use CNIC\CNR\SessionClient;
 use CNIC\IBS\SessionClient as IBSSessionClient;
 use CNIC\MONIKER\SessionClient as MONIKERSessionClient;
@@ -32,10 +33,24 @@ class ClientFactory
      * transport-faithful: the caller normalizes input (e.g. HTML-entity
      * decoding of WHMCS-stored passwords) before handing it to the client.
      *
+     * The declared return type is the shared {@see AbstractClient} base rather
+     * than a `SessionClient|IBSSessionClient|MONIKERSessionClient` union. A
+     * single common type is what consumers can reason about cleanly: every
+     * shared operation (credentials, referer, user-agent, proxy, logging,
+     * OT&E/LIVE switching, and the base `request(array $cmd)`) is available
+     * directly. Brand-specific capabilities are intentionally *not* on the
+     * shared contract and must be reached by narrowing to the concrete type —
+     * e.g. CNR session handling (`login()`/`logout()`/`saveSession()`) via
+     * `instanceof \CNIC\CNR\SessionClient`, or the IBS/Moniker per-request
+     * endpoint path (`request($cmd, $path)`) via `instanceof \CNIC\IBS\Client`.
+     * This narrowing is unavoidable for those methods under any common type,
+     * since they do not exist on all arms; the union only made the base type
+     * itself harder to consume.
+     *
      * @param string $registrar Registrar identifier (CNR, CNIC, IBS, MONIKER; case-insensitive)
      * @throws \Exception if the registrar is not supported
      */
-    public static function getClient(string $registrar): SessionClient|IBSSessionClient|MONIKERSessionClient
+    public static function getClient(string $registrar): AbstractClient
     {
         return match (Registrar::tryFrom(strtoupper($registrar))) {
             Registrar::CNR, Registrar::CNIC => new SessionClient(),

--- a/tests/ClientFactoryTest.php
+++ b/tests/ClientFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CNICTEST;
 
+use CNIC\AbstractClient;
 use CNIC\ClientFactory as CF;
 use CNIC\CNR\SessionClient as CNRSessionClient;
 use CNIC\IBS\SessionClient as IBSSessionClient;
@@ -12,6 +13,15 @@ use PHPUnit\Framework\TestCase;
 
 final class ClientFactoryTest extends TestCase
 {
+    public function testReturnsSharedAbstractClientType(): void
+    {
+        // The factory declares the shared AbstractClient contract rather than a
+        // brand-specific union, so every arm is assignable to the common type.
+        $this->assertInstanceOf(AbstractClient::class, CF::getClient("CNR"));
+        $this->assertInstanceOf(AbstractClient::class, CF::getClient("IBS"));
+        $this->assertInstanceOf(AbstractClient::class, CF::getClient("MONIKER"));
+    }
+
     public function testReturnsCnrClient(): void
     {
         $this->assertInstanceOf(CNRSessionClient::class, CF::getClient("CNR"));


### PR DESCRIPTION
## Summary

`ClientFactory::getClient()` declared a `SessionClient|IBSSessionClient|MONIKERSessionClient` return type. A 3-way union is awkward for consumers: their static analysis cannot cleanly validate calls that exist on only one arm — CNR's `login()`/`logout()`/`saveSession()` and IBS/Moniker's `request($cmd, $path)` — and there is no single type to hold.

This PR returns the shared **`AbstractClient`** base (option **B** from the ticket's weighing).

## Why AbstractClient (not a new `ClientInterface`)

Whichever common type we return, brand-specific methods **still require `instanceof` narrowing** — they genuinely don't exist on all arms, so no common type can expose them. The choice is therefore only about the *shape of the single holdable type*, and the ticket's stated concern ("does widening to `AbstractClient` lose too much for CNR consumers?") is moot: CNR consumers must narrow to reach `login()` under any option.

Given that:
- `AbstractClient` is **already** `@psalm-api` and documented as the shared foundation, and it is the **sole root** of a single-lineage hierarchy — it already *is* the client contract.
- A parallel `ClientInterface` would have to mirror ~25 public methods and stay in lockstep forever (a permanent drift tax), for benefits (interface mocking / multiple sibling implementations) this single lineage won't use. The repo's "type-hint the interface" convention exists for genuinely dual implementations (Column/Response/Logger), which the Client hierarchy is not.
- A capability-interface pair (`ClientInterface` + `SessionClientInterface`) was rejected as YAGNI — CNR is the only session-capable brand, so it would have exactly one implementer.

## Compatibility

**Runtime behaviour is unchanged** — the exact same concrete instances are returned. Static-analysis consumers calling brand-specific methods on the *union* were already getting errors (the union included arms lacking those methods) and already had to narrow, so there is no consumer regression; the union only made the base type itself harder to consume. Non-breaking → `feat` (minor).

## Changes

- `src/ClientFactory.php` — return type `AbstractClient`; docblock explains the common-type rationale and the narrowing idiom for brand capabilities.
- `tests/ClientFactoryTest.php` — new `testReturnsSharedAbstractClientType()` asserting every arm is an `AbstractClient` (existing concrete-type assertions unchanged).
- `examples/{app_CNR,app_IBS,app_MONIKER,bulk_app_CNR}.php` — demonstrate the `assert($cl instanceof …)` narrowing before using brand-specific methods, so copied examples are static-analysis clean.

## Testing

- `composer lint` — phpcs + phpstan (L9) + psalm (L1) all green.
- `composer test` — green (integration arms skip without credentials).

Jira: https://centralnic.atlassian.net/browse/RSRMID-2894

🤖 Generated with [Claude Code](https://claude.com/claude-code)