### PR TITLE
feat(client): model OT&E/LIVE as System enum; PHP 8.3 modernizations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ This is the **PHP SDK** for Team Internet backend APIs (CentralNic Reseller, Int
   - `AbstractResponseTemplateManager` — shared template container plus its `addTemplate()`/`getTemplate()`/`getTemplates()`/`hasTemplate()`/`isTemplateMatch*()` operations; subclasses redeclare their `$templates` array and supply the hooks — `generateTemplate()` (wire format), `createResponse()`, `parseResponse()`, and `matchKeys()` (the two compared hash keys: `CODE`/`DESCRIPTION` for CNR, `status`/`message` for IBS)
   - `AbstractResponseTranslator` — shared `translate()`/`findMatch()`/`replacePlaceholders()` pipeline; subclasses supply narrow hooks — `templates()` (the brand's template container), the two rewrite maps (`descriptionRegexMap()`/`descriptionRawPatternMap()`), `fieldName()` (`description` for CNR, `message` for IBS), and `hasMissingRequiredFields()` (the invalid-template fallback trigger: `CODE`/`DESCRIPTION` for CNR, `status` for IBS). Placeholder stripping is unified on a per-field callback (only inside the human-readable field), **not** global — so `{UPPER}` content in other data fields is preserved. (Ref: RSRMID-2893.)
   - `Registrar` enum — backed by string values `CNR`, `CNIC` (legacy alias), `IBS`, `MONIKER`; used by `ClientFactory` for registrar matching
+  - `System` enum — string-backed `OTE`/`LIVE`; the API system a client is on. `AbstractClient` holds it as `protected System $system` (default `LIVE`); `useOTESystem()`/`useLIVESystem()` set it, `isOTE()` and `getSystem()` read it. The public bool `isOTE()` API is preserved — the enum only replaces the internal `bool` flag. (Ref: RSRMID-2896.)
 - **Inheritance chain:**
   - `CNR\Client` and `IBS\Client` both extend `AbstractClient` directly
   - `MONIKER\Client` extends `IBS\Client` — Moniker and IBS share the same API platform; only their `SocketConfig` (endpoints/credentials) differs
@@ -190,21 +191,22 @@ Third-party actions are used directly in only two workflows (`test.yml`, `rector
 
 ## Important Files
 
-| Path                                      | Purpose                                                 |
-| ----------------------------------------- | ------------------------------------------------------- |
-| `src/AbstractSocketConfig.php`            | Shared abstract base for all SocketConfig classes       |
-| `src/AbstractResponseTemplateManager.php` | Shared base for brand ResponseTemplateManager classes   |
-| `src/AbstractResponseTranslator.php`      | Shared translate()/findMatch()/placeholder pipeline     |
-| `src/HttpTransport.php`                   | Low-level cURL HTTP transport (extracted from clients)  |
-| `src/Registrar.php`                       | `Registrar` enum — string-backed, used by ClientFactory |
-| `src/CNR/SocketConfig.php`                | CNR API endpoints and settings (typed properties)       |
-| `src/IBS/SocketConfig.php`                | IBS API endpoints and settings (typed properties)       |
-| `src/MONIKER/SocketConfig.php`            | Moniker API endpoints and settings (typed properties)   |
-| `.github/linters/phpcs.xml`               | CodeSniffer PSR-12 config                               |
-| `.github/linters/phpstan.neon`            | PHPStan level 9 (strictest) config                      |
-| `.github/linters/psalm.xml`               | Psalm level 1 (strictest) config                        |
-| `.github/phpunit.xml`                     | PHPUnit configuration                                   |
-| `env.example.sh`                          | Template for required env variables (copy to `env.sh`)  |
+| Path                                      | Purpose                                                  |
+| ----------------------------------------- | -------------------------------------------------------- |
+| `src/AbstractSocketConfig.php`            | Shared abstract base for all SocketConfig classes        |
+| `src/AbstractResponseTemplateManager.php` | Shared base for brand ResponseTemplateManager classes    |
+| `src/AbstractResponseTranslator.php`      | Shared translate()/findMatch()/placeholder pipeline      |
+| `src/HttpTransport.php`                   | Low-level cURL HTTP transport (extracted from clients)   |
+| `src/Registrar.php`                       | `Registrar` enum — string-backed, used by ClientFactory  |
+| `src/System.php`                          | `System` enum — string-backed `OTE`/`LIVE` client system |
+| `src/CNR/SocketConfig.php`                | CNR API endpoints and settings (typed properties)        |
+| `src/IBS/SocketConfig.php`                | IBS API endpoints and settings (typed properties)        |
+| `src/MONIKER/SocketConfig.php`            | Moniker API endpoints and settings (typed properties)    |
+| `.github/linters/phpcs.xml`               | CodeSniffer PSR-12 config                                |
+| `.github/linters/phpstan.neon`            | PHPStan level 9 (strictest) config                       |
+| `.github/linters/psalm.xml`               | Psalm level 1 (strictest) config                         |
+| `.github/phpunit.xml`                     | PHPUnit configuration                                    |
+| `env.example.sh`                          | Template for required env variables (copy to `env.sh`)   |
 
 ## Atlassian / JIRA
 

--- a/examples/app_IBS.php
+++ b/examples/app_IBS.php
@@ -23,7 +23,6 @@ $cl = ClientFactory::getClient("IBS");
 // the concrete Client before using it — the SDK guarantees the IBS arm is one.
 assert($cl instanceof Client);
 $cl->useOTESystem()//LIVE System would be used otherwise by default
-   //->setRemoteIPAddress("1.2.3.4") // provide ip address used for active ip filter
    ->setCredentials($user, $password)
    ->enableDebugMode();
 $r = $cl->request(["domain" => "tronexats.com"], "Domain/Info");

--- a/examples/app_MONIKER.php
+++ b/examples/app_MONIKER.php
@@ -23,7 +23,6 @@ $cl = ClientFactory::getClient("MONIKER");
 // the concrete Client before using it — the SDK guarantees the Moniker arm is one.
 assert($cl instanceof Client);
 $cl->useOTESystem()//LIVE System would be used otherwise by default
-   //->setRemoteIPAddress("1.2.3.4") // provide ip address used for active ip filter
    ->setCredentials($user, $password)
    ->enableDebugMode();
 $r = $cl->request(["tld" => "nl"], "Domain/Tldinfo");

--- a/src/AbstractClient.php
+++ b/src/AbstractClient.php
@@ -13,6 +13,7 @@ use CNIC\AbstractSocketConfig;
 use CNIC\IDNA\Factory\ConverterFactory;
 use CNIC\LoggerInterface;
 use CNIC\ResponseInterface;
+use CNIC\System;
 
 /**
  * Shared foundation for all registrar API clients.
@@ -69,9 +70,9 @@ abstract class AbstractClient
     protected LoggerInterface $logger;
 
     /**
-     * is connected to OT&E
+     * API system the client is connected to (defaults to LIVE)
      */
-    protected bool $isOTE = false;
+    protected System $system = System::LIVE;
 
     /**
      * HTTP transport layer
@@ -419,11 +420,19 @@ abstract class AbstractClient
     }
 
     /**
+     * Get the API system the client is currently connected to
+     */
+    public function getSystem(): System
+    {
+        return $this->system;
+    }
+
+    /**
      * Check whether the client is connected to the OT&E system
      */
     public function isOTE(): bool
     {
-        return $this->isOTE;
+        return $this->system === System::OTE;
     }
 
     /**
@@ -431,7 +440,7 @@ abstract class AbstractClient
      */
     public function useOTESystem(): static
     {
-        $this->isOTE = true;
+        $this->system = System::OTE;
         return $this->setURL($this->socketConfig->getOTEUrl());
     }
 
@@ -440,7 +449,7 @@ abstract class AbstractClient
      */
     public function useLIVESystem(): static
     {
-        $this->isOTE = false;
+        $this->system = System::LIVE;
         return $this->setURL($this->socketConfig->getLiveUrl());
     }
 

--- a/src/CNR/Response.php
+++ b/src/CNR/Response.php
@@ -147,7 +147,7 @@ class Response implements ResponseInterface
         $this->hash = RP::parse($this->raw);
         $properties = $this->hash["PROPERTY"] ?? null;
         if (is_array($properties)) {
-            $colKeys = array_map("strval", array_keys($properties));
+            $colKeys = array_map(strval(...), array_keys($properties));
             foreach ($colKeys as $k) {
                 $this->addColumn($k, $properties[$k]);
             }
@@ -165,7 +165,7 @@ class Response implements ResponseInterface
      */
     protected function sanitizeCommand(array $cmd): array
     {
-        $sensitive = array_map("strtolower", $this->sensitiveFields);
+        $sensitive = array_map(strtolower(...), $this->sensitiveFields);
         foreach (array_keys($cmd) as $key) {
             if (in_array(strtolower($key), $sensitive, true)) {
                 $cmd[$key] = "***";

--- a/src/CNR/ResponseTemplateManager.php
+++ b/src/CNR/ResponseTemplateManager.php
@@ -56,7 +56,7 @@ final class ResponseTemplateManager extends AbstractResponseTemplateManager
     #[\Override]
     public static function getTemplate(string $id): Response
     {
-        return static::createResponse(static::hasTemplate($id) ? $id : "notfound");
+        return self::createResponse(self::hasTemplate($id) ? $id : "notfound");
     }
 
     /**

--- a/src/CNR/ResponseTranslator.php
+++ b/src/CNR/ResponseTranslator.php
@@ -23,7 +23,7 @@ final class ResponseTranslator extends AbstractResponseTranslator
      * plain-string description keys for translation; keys are preg_quote'd before matching
      * @var array<string, string>
      */
-    private static array $descriptionRegexMap = [
+    private const array DESCRIPTION_REGEX_MAP = [
         // HX - just for future reference, can be cleaned up if we have something similar in place for CNR (used in test automation currently)
         "Authorization failed; Operation forbidden by ACL" => "Authorization failed; Used Command `{COMMAND}` not white-listed by your Access Control List",
         // CNR
@@ -34,7 +34,7 @@ final class ResponseTranslator extends AbstractResponseTranslator
      * raw regex pattern keys for translation; keys are used as-is (not preg_quote'd)
      * @var array<string, string>
      */
-    private static array $descriptionRawPatternMap = [
+    private const array DESCRIPTION_RAW_PATTERN_MAP = [
         // HX - just for future reference
         //"Invalid attribute value syntax; resource record \[(.+)\]" => "Invalid Syntax for DNSZone Resource Record: $1",
         //"Missing required attribute; CLASS(?:=| \[MUST BE )PREMIUM_([\w\+]+)[\s\]]" => "Confirm the Premium pricing by providing the parameter CLASS with the value PREMIUM_$1.",
@@ -59,7 +59,7 @@ final class ResponseTranslator extends AbstractResponseTranslator
     #[\Override]
     protected static function descriptionRegexMap(): array
     {
-        return self::$descriptionRegexMap;
+        return self::DESCRIPTION_REGEX_MAP;
     }
 
     /**
@@ -68,7 +68,7 @@ final class ResponseTranslator extends AbstractResponseTranslator
     #[\Override]
     protected static function descriptionRawPatternMap(): array
     {
-        return self::$descriptionRawPatternMap;
+        return self::DESCRIPTION_RAW_PATTERN_MAP;
     }
 
     /**

--- a/src/CommandFormatter.php
+++ b/src/CommandFormatter.php
@@ -17,12 +17,52 @@ namespace CNIC;
 final class CommandFormatter
 {
     /**
+     * Static priority seed: the base property patterns plus the contact type and
+     * field patterns from which getPropertiesPriority() builds the full map. The
+     * data never changes at runtime, so it lives as a class constant rather than
+     * a rebuilt-per-call literal.
+     * @var array{properties: array<string, int>, contact: array{types: array<string, int>, fields: array<string, int>}}
+     */
+    private const array CONTACT_FIELDS_PRIORITY = [
+        "properties" => [
+            "COMMAND" => 1,
+            "/^(DOMAIN|DNSZONE|NAMESERVER|ZONE|SUBUSER)[0-9]*$/i" => 2,
+            "/^(PERIOD|ACTION|AUTH|TARGET|X-FEE-COMMAND|RENEWALMODE|LIMIT|WIDE)$/i" => 3,
+            "/^(NS_LIST|TRANSFERLOCK|DNSSEC0|X-FEE-AMOUNT|LOG|TYPE|OBJECT|INACTIVE|OBJECTID|OBJECTCLASS|ORDER|ORDERBY|CURRENCYFROM|CURRENCYTO)$/i" => 4,
+        ],
+        "contact" => [
+            "types" => [
+                "OWNERCONTACT|REGISTRANT" => 5,
+                "ADMINCONTACT|TECHNICAL" => 6,
+                "TECHCONTACT|BILLING" => 7,
+                "BILLINGCONTACT|ADMIN" => 8,
+            ],
+            "fields" => [
+                "FIRSTNAME" => 1,
+                "MIDDLENAME" => 2,
+                "LASTNAME" => 3,
+                "ORGANIZATION" => 4,
+                "STREET" => 5,
+                "ZIP" => 6,
+                "CITY" => 7,
+                "STATE" => 8,
+                "COUNTRY" => 9,
+                "PHONE|PHONENUMBER" => 10,
+                "EMAIL" => 11,
+                "CONTACT" => 12,
+                "LEGALFORM" => 13,
+                "IDENTIFICACION" => 14,
+                "TIPO-IDENTIFICACION" => 15,
+            ]
+        ]
+    ];
+
+    /**
      * Memoized priority map produced by getPropertiesPriority().
-     * The map is derived from purely static data (see
-     * getPropertiesContactFieldsWithPriority()) and never depends on the
-     * command being sorted, so it is built once per process and reused across
-     * every getSortedCommand() call (each request flatten and each response
-     * getCommand()).
+     * The map is derived from purely static data (see CONTACT_FIELDS_PRIORITY)
+     * and never depends on the command being sorted, so it is built once per
+     * process and reused across every getSortedCommand() call (each request
+     * flatten and each response getCommand()).
      * @var array<string,int>|null
      */
     private static ?array $priorityCache = null;
@@ -96,48 +136,6 @@ final class CommandFormatter
     }
 
     /**
-     * Assign the priority of each key in the command array based on the key pattern
-     *
-     * @return array{properties: array<string, int>, contact: array{types: array<string, int>, fields: array<string, int>}}
-     */
-    private static function getPropertiesContactFieldsWithPriority(): array
-    {
-        return [
-            "properties" => [
-                "COMMAND" => 1,
-                "/^(DOMAIN|DNSZONE|NAMESERVER|ZONE|SUBUSER)[0-9]*$/i" => 2,
-                "/^(PERIOD|ACTION|AUTH|TARGET|X-FEE-COMMAND|RENEWALMODE|LIMIT|WIDE)$/i" => 3,
-                "/^(NS_LIST|TRANSFERLOCK|DNSSEC0|X-FEE-AMOUNT|LOG|TYPE|OBJECT|INACTIVE|OBJECTID|OBJECTCLASS|ORDER|ORDERBY|CURRENCYFROM|CURRENCYTO)$/i" => 4,
-            ],
-            "contact" => [
-                "types" => [
-                    "OWNERCONTACT|REGISTRANT" => 5,
-                    "ADMINCONTACT|TECHNICAL" => 6,
-                    "TECHCONTACT|BILLING" => 7,
-                    "BILLINGCONTACT|ADMIN" => 8,
-                ],
-                "fields" => [
-                    "FIRSTNAME" => 1,
-                    "MIDDLENAME" => 2,
-                    "LASTNAME" => 3,
-                    "ORGANIZATION" => 4,
-                    "STREET" => 5,
-                    "ZIP" => 6,
-                    "CITY" => 7,
-                    "STATE" => 8,
-                    "COUNTRY" => 9,
-                    "PHONE|PHONENUMBER" => 10,
-                    "EMAIL" => 11,
-                    "CONTACT" => 12,
-                    "LEGALFORM" => 13,
-                    "IDENTIFICACION" => 14,
-                    "TIPO-IDENTIFICACION" => 15,
-                ]
-            ]
-        ];
-    }
-
-    /**
      * Generate the priority array with properties dynamically including contact fields and their priority
      *
      * @return array<string,int> The priority array
@@ -148,7 +146,7 @@ final class CommandFormatter
             return self::$priorityCache;
         }
 
-        $propertiesWithPriority = self::getPropertiesContactFieldsWithPriority();
+        $propertiesWithPriority = self::CONTACT_FIELDS_PRIORITY;
 
         foreach ($propertiesWithPriority["contact"]["types"] as $typePattern => $typePriority) {
             foreach ($propertiesWithPriority["contact"]["fields"] as $fieldPattern => $fieldPriority) {

--- a/src/IBS/Response.php
+++ b/src/IBS/Response.php
@@ -79,7 +79,7 @@ class Response extends CNRResponse implements ResponseInterface
     protected function populate(): void
     {
         $this->hash = RP::parse($this->raw, $this->command);
-        $colKeys = array_map("strval", array_keys($this->hash));
+        $colKeys = array_map(strval(...), array_keys($this->hash));
         foreach ($colKeys as $k) {
             $this->addColumn($k, is_array($this->hash[$k]) && array_is_list($this->hash[$k]) ? $this->hash[$k] : [$this->hash[$k]]);
         }

--- a/src/IBS/ResponseTemplateManager.php
+++ b/src/IBS/ResponseTemplateManager.php
@@ -56,7 +56,7 @@ final class ResponseTemplateManager extends AbstractResponseTemplateManager
     #[\Override]
     public static function getTemplate(string $id): Response
     {
-        return static::createResponse(static::hasTemplate($id) ? $id : "notfound");
+        return self::createResponse(self::hasTemplate($id) ? $id : "notfound");
     }
 
     /**

--- a/src/IBS/ResponseTranslator.php
+++ b/src/IBS/ResponseTranslator.php
@@ -28,13 +28,13 @@ final class ResponseTranslator extends AbstractResponseTranslator
      * plain-string description keys for translation; keys are preg_quote'd before matching
      * @var array<string, string>
      */
-    private static array $descriptionRegexMap = [];
+    private const array DESCRIPTION_REGEX_MAP = [];
 
     /**
      * raw regex pattern keys for translation; keys are used as-is (not preg_quote'd)
      * @var array<string, string>
      */
-    private static array $descriptionRawPatternMap = [];
+    private const array DESCRIPTION_RAW_PATTERN_MAP = [];
 
     /**
      * The IBS static template container.
@@ -52,7 +52,7 @@ final class ResponseTranslator extends AbstractResponseTranslator
     #[\Override]
     protected static function descriptionRegexMap(): array
     {
-        return self::$descriptionRegexMap;
+        return self::DESCRIPTION_REGEX_MAP;
     }
 
     /**
@@ -61,7 +61,7 @@ final class ResponseTranslator extends AbstractResponseTranslator
     #[\Override]
     protected static function descriptionRawPatternMap(): array
     {
-        return self::$descriptionRawPatternMap;
+        return self::DESCRIPTION_RAW_PATTERN_MAP;
     }
 
     /**

--- a/src/System.php
+++ b/src/System.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * CNIC
+ * Copyright © Team Internet Group PLC
+ */
+
+namespace CNIC;
+
+/**
+ * API system a client is connected to.
+ *
+ * OT&E is the test/sandbox environment; LIVE is production. A client is always
+ * on exactly one of the two, so the state is modelled as this enum rather than a
+ * boolean flag.
+ *
+ * @psalm-api
+ * @package CNIC
+ */
+enum System: string
+{
+    case OTE  = "OTE";
+    case LIVE = "LIVE";
+}

--- a/tests/CNR/ClientTest.php
+++ b/tests/CNR/ClientTest.php
@@ -12,6 +12,7 @@ use CNIC\CNR\Response as R;
 use CNIC\CNR\ResponseTemplateManager as RTM;
 use CNIC\CNR\SessionClient;
 use CNIC\IDNA\Factory\ConverterFactory;
+use CNIC\System;
 use PHPUnit\Framework\TestCase;
 
 final class ClientTest extends TestCase
@@ -140,6 +141,22 @@ final class ClientTest extends TestCase
     {
         $url = self::$cl->getURL();
         $this->assertEquals($url, self::$cl->getLiveUrl());
+    }
+
+    public function testGetSystem(): void
+    {
+        // LIVE is the default; isOTE() must agree with getSystem()
+        $this->assertSame(System::LIVE, self::$cl->getSystem());
+        $this->assertFalse(self::$cl->isOTE());
+
+        self::$cl->useOTESystem();
+        $this->assertSame(System::OTE, self::$cl->getSystem());
+        $this->assertTrue(self::$cl->isOTE());
+
+        // restore default so later tests keep the expected baseline
+        self::$cl->useLIVESystem();
+        $this->assertSame(System::LIVE, self::$cl->getSystem());
+        $this->assertFalse(self::$cl->isOTE());
     }
 
     public function testGetUserAgent(): void


### PR DESCRIPTION
## Summary

Implements [RSRMID-2896](https://centralnic.atlassian.net/browse/RSRMID-2896) — minor PHP 8.3 modernizations the configured Rector rulesets do not flag, plus a stale-example fix.

### Changes

- **`System` enum for OT&E/LIVE** — new `CNIC\System` (string-backed `OTE`/`LIVE`) replaces `AbstractClient`'s internal `bool $isOTE`. Adds a typed `getSystem()` accessor. The existing public API (`isOTE()`, `useOTESystem()`, `useLIVESystem()`) is **unchanged** — only the internal representation moved from `bool` to enum.
- **`private static` maps → `private const array`** — the never-reassigned translation maps in `CNR\ResponseTranslator` / `IBS\ResponseTranslator`, and the contact-field priority literal in `CommandFormatter` (extracted to `CONTACT_FIELDS_PRIORITY`).
- **First-class callable syntax** — `array_map("strval", …)` / `array_map("strtolower", …)` → `array_map(strval(...), …)` / `array_map(strtolower(...), …)` in `CNR\Response` / `IBS\Response`.
- **Rector re-run** — applied the `static:: → self::` simplification in `CNR`/`IBS` `ResponseTemplateManager` (both `final`, so behaviour-preserving); Rector dry-run is now clean.
- **Stale example fix** — removed the `setRemoteIPAddress()` comment from `examples/app_IBS.php` and `examples/app_MONIKER.php` (the method never existed in `src/`).

### Verification

- `composer rector` — clean
- `composer lint` — phpcs + PHPStan L9 + Psalm L1 all pass
- `composer test` — 296 passed, 1 pre-existing skip
- Added `testGetSystem` covering `getSystem()`/`isOTE()` across the OT&E/LIVE toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RSRMID-2896]: https://centralnic.atlassian.net/browse/RSRMID-2896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ