### PR TITLE
fix(logging): extend debug output masking to all sensitive command fields

### DIFF
--- a/src/AbstractSocketConfig.php
+++ b/src/AbstractSocketConfig.php
@@ -54,6 +54,18 @@ abstract class AbstractSocketConfig
     protected string $roleSeparator = "";
 
     /**
+     * Command parameter keys whose values carry sensitive data (account
+     * password, domain authorization code, ...) and must be masked in the
+     * "secured" POST body used for debug logging. Matching is case-insensitive
+     * (see maskSensitiveCommand()), so only the names matter, not their casing.
+     * Brand subclasses declare the keys their API uses; this mirrors the
+     * corresponding Response::$sensitiveFields set for each brand so the debug
+     * mask and the stored-command mask cover the same fields.
+     * @var string[]
+     */
+    protected array $sensitiveFields = [];
+
+    /**
      * Set account name to use
      * @param string $value account name
      */
@@ -152,6 +164,27 @@ abstract class AbstractSocketConfig
     public function getRoleSeparator(): string
     {
         return $this->roleSeparator;
+    }
+
+    /**
+     * Mask the values of the brand's sensitive command keys (see
+     * $sensitiveFields) so command-level secrets — e.g. a domain transfer
+     * authorization code — never reach the debug log in cleartext. Matching is
+     * case-insensitive to stay robust against casing differences between what a
+     * brand documents and what it actually sends. `null` values are left
+     * untouched (they are dropped from the request, not logged).
+     * @param array<string, string|null> $command API Command to mask
+     * @return array<string, string|null>
+     */
+    protected function maskSensitiveCommand(array $command): array
+    {
+        $sensitive = array_map(strtolower(...), $this->sensitiveFields);
+        foreach ($command as $key => $val) {
+            if ($val !== null && in_array(strtolower($key), $sensitive, true)) {
+                $command[$key] = "***";
+            }
+        }
+        return $command;
     }
 
     /**

--- a/src/CNR/SocketConfig.php
+++ b/src/CNR/SocketConfig.php
@@ -25,6 +25,13 @@ final class SocketConfig extends AbstractSocketConfig
     protected string $roleSeparator = ":";
 
     /**
+     * CNR carries sensitive data under upper-case command keys. Mirrors
+     * {@see \CNIC\CNR\Response::$sensitiveFields}.
+     * @var string[]
+     */
+    protected array $sensitiveFields = ["PASSWORD", "AUTH"];
+
+    /**
      * Parameter to trigger creation of a backend session
      */
     private bool $persistent = false;
@@ -65,13 +72,13 @@ final class SocketConfig extends AbstractSocketConfig
             $params[$this->parameters["session"]] = $this->session;
         }
         if ($command !== []) {
+            if ($secured) {
+                $command = $this->maskSensitiveCommand($command);
+            }
             $newcommand = "";
             foreach ($command as $key => $val) {
                 if ($val === null) {
                     continue;
-                }
-                if ($secured && preg_match("/^PASSWORD$/i", $key)) {
-                    $val = "***";
                 }
                 $newcommand .= "{$key}={$val}\n";
             }

--- a/src/IBS/SocketConfig.php
+++ b/src/IBS/SocketConfig.php
@@ -24,6 +24,13 @@ class SocketConfig extends AbstractSocketConfig
     protected bool $needsIDNConvert = false;
 
     /**
+     * IBS carries sensitive data under lower-/camel-case command keys. Mirrors
+     * {@see \CNIC\IBS\Response::$sensitiveFields}.
+     * @var string[]
+     */
+    protected array $sensitiveFields = ["password", "transferAuthInfo"];
+
+    /**
      * list of http request parameters
      * IBS only uses login/password — command and session are CNR-specific.
      * @var array{login: string, password: string}
@@ -42,7 +49,7 @@ class SocketConfig extends AbstractSocketConfig
     #[\Override]
     protected function getPOSTDataParams(array $command, bool $secured): array
     {
-        $params = $command;
+        $params = $secured ? $this->maskSensitiveCommand($command) : $command;
         if (strlen($this->login) !== 0) {
             $params[$this->parameters["login"]] = $this->login;
         }

--- a/tests/CNR/ClientTest.php
+++ b/tests/CNR/ClientTest.php
@@ -103,6 +103,28 @@ final class ClientTest extends TestCase
         );
     }
 
+    public function testGetPostDataSecuredMasksAuth(): void
+    {
+        // AUTH (EPP transfer authorization code) must be masked in the secured
+        // POST body used for debug logging, not only PASSWORD (RSRMID-2897).
+        $enc = self::$cl->getPOSTData([
+            "COMMAND" => "TransferDomain",
+            "DOMAIN" => "example.com",
+            "AUTH" => "sup3r-s3cr3t-auth"
+        ], true);
+
+        $expected = http_build_query([
+            "s_command" => implode("\n", [
+                "COMMAND=TransferDomain",
+                "DOMAIN=example.com",
+                "AUTH=***"
+            ])
+        ]);
+
+        $this->assertEquals($expected, $enc);
+        $this->assertStringNotContainsString("sup3r-s3cr3t-auth", $enc);
+    }
+
     public function testGetPostDataObj(): void
     {
         $enc = self::$cl->getPOSTData([

--- a/tests/IBS/SocketConfigTest.php
+++ b/tests/IBS/SocketConfigTest.php
@@ -35,6 +35,33 @@ final class SocketConfigTest extends TestCase
         );
     }
 
+    public function testGetPOSTDataSecuredMasksTransferAuthInfo(): void
+    {
+        // transferAuthInfo (domain auth code) must be masked in the secured
+        // POST body used for debug logging, alongside the account password
+        // (RSRMID-2897).
+        $sc = new SC();
+        $sc->setLogin("myuser")->setPassword("mypw");
+        $raw = $sc->getPOSTData([
+            "Domain" => "test.com",
+            "transferAuthInfo" => "sup3r-s3cr3t-auth"
+        ], true);
+        $this->assertStringContainsString("transferAuthInfo=%2A%2A%2A", $raw);
+        $this->assertStringContainsString("password=%2A%2A%2A", $raw);
+        $this->assertStringNotContainsString("sup3r-s3cr3t-auth", $raw);
+    }
+
+    public function testGetPOSTDataUnsecuredKeepsTransferAuthInfo(): void
+    {
+        // On the actual wire request (not secured) the value must pass through.
+        $sc = new SC();
+        $raw = $sc->getPOSTData([
+            "Domain" => "test.com",
+            "transferAuthInfo" => "sup3r-s3cr3t-auth"
+        ]);
+        $this->assertStringContainsString("transferAuthInfo=sup3r-s3cr3t-auth", $raw);
+    }
+
     public function testGetPOSTDataLoginOnly(): void
     {
         $sc = new SC();


### PR DESCRIPTION
## Summary

Extends the debug-output hide mechanism so that **every** command key a brand marks as sensitive is masked in the "secured" POST body used for debug logging.

Previously each `SocketConfig` masked a narrower, hard-coded subset than the brand's `Response::$sensitiveFields` already declared, so the two masks could drift apart and some sensitive command values reached the debug log in cleartext.

## Changes

- Hoist a shared, case-insensitive `maskSensitiveCommand()` helper and a brand-declared `$sensitiveFields` property into `AbstractSocketConfig`.
- CNR and IBS/Moniker `SocketConfig` now declare the same field set their `Response` already uses and route the secured POST body through the shared helper — a single code path for both brands.
- Regression tests covering a command-level sensitive value on CNR and IBS.

Non-breaking; masking only applies in secured/debug output — the actual wire request is unchanged.

## Testing

- `composer test` — green
- `composer lint` (phpcs + phpstan L9 + psalm L1) — clean

Jira: https://centralnic.atlassian.net/browse/RSRMID-2897

🤖 Generated with [Claude Code](https://claude.com/claude-code)