### PR TITLE
test(client): cover AbstractClient::setContext() round-trip

### DIFF
--- a/tests/CNR/ClientTest.php
+++ b/tests/CNR/ClientTest.php
@@ -211,18 +211,18 @@ final class ClientTest extends TestCase
 
     public function testSetContext(): void
     {
+        // use a dedicated client so credential/context state does not leak
+        // into the shared static client used by the other tests
+        $cl = new SessionClient();
         $context = ["traceId" => "abc123", "attempt" => 1];
-        $cls = self::$cl->setContext($context);
+        $cls = $cl->setContext($context);
         $this->assertInstanceOf(CL::class, $cls);
 
         // context set on the client must propagate into every Response
-        self::$cl->setCredentials(self::$user, self::$pw)
+        $cl->setCredentials(self::$user, self::$pw)
             ->useOTESystem();
-        $r = self::$cl->request(["COMMAND" => "CheckDomains", "DOMAIN" => ["example.com"]]);
+        $r = $cl->request(["COMMAND" => "CheckDomains", "DOMAIN" => ["example.com"]]);
         $this->assertSame($context, $r->getContext());
-
-        // reset so later tests are unaffected
-        self::$cl->setContext([]);
     }
 
     public function testSetUrl(): void

--- a/tests/CNR/ClientTest.php
+++ b/tests/CNR/ClientTest.php
@@ -209,6 +209,22 @@ final class ClientTest extends TestCase
         $this->assertEquals(self::$cl->getUserAgent(), $ua);
     }
 
+    public function testSetContext(): void
+    {
+        $context = ["traceId" => "abc123", "attempt" => 1];
+        $cls = self::$cl->setContext($context);
+        $this->assertInstanceOf(CL::class, $cls);
+
+        // context set on the client must propagate into every Response
+        self::$cl->setCredentials(self::$user, self::$pw)
+            ->useOTESystem();
+        $r = self::$cl->request(["COMMAND" => "CheckDomains", "DOMAIN" => ["example.com"]]);
+        $this->assertSame($context, $r->getContext());
+
+        // reset so later tests are unaffected
+        self::$cl->setContext([]);
+    }
+
     public function testSetUrl(): void
     {
         $oldurl = self::$cl->getURL();


### PR DESCRIPTION
## Summary

Closes the test-coverage gap on `AbstractClient::setContext()` ([src/AbstractClient.php:460](src/AbstractClient.php#L460)). Previously only `getContext()` on the Response was exercised; `setContext()` had zero references in `tests/`.

Adds a test to `tests/CNR/ClientTest.php` that:
- asserts `setContext()` returns the fluent client instance, and
- verifies the context propagates end-to-end into the resulting `Response` via `getContext()`.

Test-only change — no `src/` changes.

## Jira

https://centralnic.atlassian.net/browse/RSRMID-2900

🤖 Generated with [Claude Code](https://claude.com/claude-code)