### PR TITLE
refactor(command-formatter): precompute per-key priority in getSortedCommand()

### DIFF
--- a/src/CommandFormatter.php
+++ b/src/CommandFormatter.php
@@ -77,10 +77,19 @@ final class CommandFormatter
     {
         $priority = self::getPropertiesPriority();
 
+        // Decorate-sort-undecorate: resolve each key's priority exactly once
+        // (O(n) findPriority calls) into a cache, then have the comparator read
+        // the cached ints instead of re-scanning ~65 regex patterns on every
+        // one of the ~2*n*log(n) comparisons.
+        $keyPriority = [];
+        foreach (array_keys($command) as $key) {
+            $keyPriority[$key] = self::findPriority($key, $priority);
+        }
+
         // Sort the command array based on priority
-        uksort($command, function (string $a, string $b) use ($priority) {
-            $priorityA = self::findPriority($a, $priority);
-            $priorityB = self::findPriority($b, $priority);
+        uksort($command, function (string $a, string $b) use ($keyPriority) {
+            $priorityA = $keyPriority[$a];
+            $priorityB = $keyPriority[$b];
 
             return $priorityA === $priorityB ? strcmp($a, $b) : $priorityA - $priorityB;
         });


### PR DESCRIPTION
## Summary

Optimizes `CommandFormatter::getSortedCommand()` using the decorate-sort-undecorate pattern.

Previously the `uksort` comparator called `findPriority()` on **both** keys for every comparison, and `findPriority()` is a linear scan over ~65 `preg_match` patterns. A sort of *n* keys does ~2·*n*·log(*n*) comparator invocations, so regex work scaled as O(*n* log *n*). This runs on every request (`flattenCommand`) and every `Response::getCommand()`.

Now each key's priority is resolved **exactly once** into a `[key => priority]` map (O(*n*) `findPriority` calls), and the comparator reads the cached ints. Regex work drops to O(*n*) with byte-for-byte identical ordering (still `strcmp` fallback on equal priority).

## Acceptance criteria

- [x] Sort output byte-for-byte identical — existing `CommandFormatterTest` stays green (12 passed)
- [x] Each key's priority resolved at most once per sort
- [x] phpcs + phpstan (L9) + psalm (L1) green; `CommandFormatter` coverage still 100%

Jira: https://centralnic.atlassian.net/browse/RSRMID-2901

🤖 Generated with [Claude Code](https://claude.com/claude-code)