### PR TITLE
refactor(response): narrow CNR pagination getters to ColumnInterface

### DIFF
--- a/src/CNR/Response.php
+++ b/src/CNR/Response.php
@@ -471,15 +471,27 @@ class Response implements ResponseInterface
     }
 
     /**
+     * Coerce a raw pagination column value to a base-10 integer.
+     *
+     * getDataByIndex() is typed mixed on ColumnInterface (IBS columns may
+     * carry nested arrays/objects); the pagination columns FIRST/LAST/TOTAL/
+     * LIMIT always hold a scalar numeric string, so anything non-scalar (incl.
+     * a missing value) yields null and lets the caller fall back.
+     */
+    private function columnInt(mixed $value): ?int
+    {
+        return is_scalar($value) ? intval($value, 10) : null;
+    }
+
+    /**
      * Get Index of first row in this response
      */
     #[\Override]
     public function getFirstRecordIndex(): ?int
     {
         $col = $this->getColumn("FIRST");
-        if ($col instanceof Column) {
-            $f = $col->getDataByIndex(0);
-            return $f === null ? 0 : intval($f, 10);
+        if ($col instanceof ColumnInterface) {
+            return $this->columnInt($col->getDataByIndex(0)) ?? 0;
         }
         if ($this->getRecordsCount() !== 0) {
             return 0;
@@ -494,10 +506,10 @@ class Response implements ResponseInterface
     public function getLastRecordIndex(): ?int
     {
         $col = $this->getColumn("LAST");
-        if ($col instanceof Column) {
-            $l = $col->getDataByIndex(0);
+        if ($col instanceof ColumnInterface) {
+            $l = $this->columnInt($col->getDataByIndex(0));
             if ($l !== null) {
-                return intval($l, 10);
+                return $l;
             }
         }
         $c = $this->getRecordsCount();
@@ -664,10 +676,10 @@ class Response implements ResponseInterface
     public function getRecordsTotalCount(): int
     {
         $col = $this->getColumn("TOTAL");
-        if ($col instanceof Column) {
-            $t = $col->getDataByIndex(0);
+        if ($col instanceof ColumnInterface) {
+            $t = $this->columnInt($col->getDataByIndex(0));
             if ($t !== null) {
-                return intval($t, 10);
+                return $t;
             }
         }
         return $this->getRecordsCount();
@@ -681,10 +693,10 @@ class Response implements ResponseInterface
     public function getRecordsLimitation(): int
     {
         $col = $this->getColumn("LIMIT");
-        if ($col instanceof Column) {
-            $l = $col->getDataByIndex(0);
+        if ($col instanceof ColumnInterface) {
+            $l = $this->columnInt($col->getDataByIndex(0));
             if ($l !== null) {
-                return intval($l, 10);
+                return $l;
             }
         }
         return $this->getRecordsCount();


### PR DESCRIPTION
## Summary

CNR pagination getters narrowed `getColumn()`'s `?ColumnInterface` result with `instanceof Column` (the concrete CNR class), contradicting the CLAUDE.md rule to type-hint against the interface. This aligns them with the interface.

Affected getters in `src/CNR/Response.php`:
- `getFirstRecordIndex()`
- `getLastRecordIndex()`
- `getRecordsTotalCount()`
- `getRecordsLimitation()`

## Why the concrete check existed

`CNR\Column::getDataByIndex()` returns `string|null`, but `ColumnInterface::getDataByIndex()` returns `mixed` (IBS columns carry mixed JSON values). A bare interface swap made `intval(mixed)` fail PHPStan L9 (`argument.type`) and Psalm L1 (`MixedAssignment`).

## Change

- Switch all four to `instanceof ColumnInterface`.
- Route the raw value through a new private `columnInt(mixed): ?int` helper that narrows via `is_scalar()` before `intval()` — green on both analysers with **no suppressions**, and de-duplicating the repeated conversion.
- Behaviour is unchanged: CNR pagination columns always hold a scalar numeric string.

## IBS overrides retained

`IBS\Response` pagination overrides encode **genuine single-page semantics** (unconditional `0`, records-grounded `LAST`, no column lookup), not a workaround for the concrete check — so none can be dropped.

## Acceptance criteria

- [x] CNR and IBS pagination behaviour unchanged; full test suite green.
- [x] Concrete-class narrowing removed in favour of the interface where semantically safe.
- [x] phpstan (L9) + psalm (L1) remain green.

Jira: https://centralnic.atlassian.net/browse/RSRMID-2902

🤖 Generated with [Claude Code](https://claude.com/claude-code)