### PR TITLE
refactor(response): strip getListHash() pagination keys per column-set

### DIFF
--- a/src/CNR/Response.php
+++ b/src/CNR/Response.php
@@ -526,20 +526,21 @@ class Response implements ResponseInterface
     #[\Override]
     public function getListHash(): array
     {
+        // Resolve the pagination-stripped column set once (regex runs a single
+        // time inside getColumnKeys(true)); reuse it to filter every row via
+        // array_intersect_key instead of a per-cell preg_match. Record data keys
+        // are always a subset of the column keys (see assembleRecords()), so this
+        // yields output identical to unsetting each pagination-matching cell.
+        $columns = $this->getColumnKeys(true);
+        $keepKeys = array_flip($columns);
         $lh = [];
         foreach ($this->records as $rec) {
-            $data = $rec->getData();
-            foreach (array_keys($data) as $col) {
-                if ((bool)preg_match($this->paginationkeys, $col)) {
-                    unset($data[$col]);
-                }
-            }
-            $lh[] = $data;
+            $lh[] = array_intersect_key($rec->getData(), $keepKeys);
         }
         return [
             "LIST" => $lh,
             "meta" => [
-                "columns" => $this->getColumnKeys(true),
+                "columns" => $columns,
                 "pg" => $this->getPagination()
             ]
         ];


### PR DESCRIPTION
## Summary

`CNR\Response::getListHash()` ran `preg_match` against the pagination-keys regex for **every cell** (O(rows×cols) regex calls) and then separately called `getColumnKeys(true)`, recomputing the same strip set.

This resolves the pagination-stripped column set **once** and filters each row with `array_intersect_key`, reusing that single result for `meta.columns` too. Regex is now evaluated once per column-set instead of once per cell.

Record data keys are always a subset of the column keys (see `assembleRecords()`), so output is identical for populated, empty and paginated lists.

## Acceptance criteria

- [x] `getListHash()` output identical for populated, empty and paginated lists; existing tests green
- [x] Pagination regex evaluated once per column set, not once per cell
- [x] phpstan (L9) + psalm (L1) remain green

Jira: https://centralnic.atlassian.net/browse/RSRMID-2903