### PR TITLE
test(ibs): raise CNIC\IBS\Response to 100% coverage (RSRMID-2905)

### DIFF
--- a/tests/IBS/ResponseNavigationTest.php
+++ b/tests/IBS/ResponseNavigationTest.php
@@ -145,6 +145,20 @@ final class ResponseNavigationTest extends TestCase
         $this->assertEquals(0, $r->getLastRecordIndex());
     }
 
+    public function testGetLastRecordIndexIsNullWhenNoRecords(): void
+    {
+        // A response whose every column is an empty list assembles to zero
+        // records. With no rows there is no meaningful last index, so
+        // getLastRecordIndex() returns null instead of underflowing to -1 —
+        // keeping the pagination block coherent for the empty case. The sole
+        // "status" column being an empty list still satisfies the translator's
+        // status-present check (so the invalid-response template is NOT applied)
+        // yet contributes no rows.
+        $r = new R('{"status":[]}', self::JSONCMD);
+        $this->assertEquals(0, $r->getRecordsCount());
+        $this->assertNull($r->getLastRecordIndex());
+    }
+
     // --- column access ---
 
     public function testGetColumnIndex(): void


### PR DESCRIPTION
## Summary

Closes the single coverage gap in `CNIC\IBS\Response`: the `return null` branch of `getLastRecordIndex()` — taken when the assembled record count is `0` — was the only uncovered line, leaving the class at 95.24% methods.

## Change

Adds one template-driven test (`testGetLastRecordIndexIsNullWhenNoRecords`) in `tests/IBS/ResponseNavigationTest.php`. It constructs an all-empty-column response `{"status":[]}`:

- the empty-list `status` column still satisfies the translator's status-present check, so the invalid-response fallback template is **not** applied;
- yet it contributes no rows, so record assembly produces **zero** records;
- `getLastRecordIndex()` therefore returns `null` (rather than underflowing to `-1`), keeping the pagination block coherent for the empty case.

No `src/` changes — test-only.

## Verification

- `CNIC\IBS\Response`: **16/16 methods, 36/36 lines (100%)** — no uncovered lines.
- `composer lint` clean (phpcs, phpstan L9, psalm L1).
- Suite green.

Jira: https://centralnic.atlassian.net/browse/RSRMID-2905

🤖 Generated with [Claude Code](https://claude.com/claude-code)