### PR TITLE
feat(client): add setExtraCurlOptions()/resetCurlOptions() for per-client cURL tuning

### DIFF
--- a/src/AbstractClient.php
+++ b/src/AbstractClient.php
@@ -58,7 +58,10 @@ abstract class AbstractClient
     protected string $ua = "";
 
     /**
-     * additional curl options to use
+     * Live cURL options bag applied to every request. Initialised in the
+     * constructor from {@see getDefaultCurlOpts()} (brand defaults) and then
+     * mutated by {@see setProxy()}/{@see setReferer()}/{@see setExtraCurlOptions()};
+     * {@see resetCurlOptions()} restores it to the brand defaults.
      * @var array<int, mixed>
      */
     protected array $curlopts = [];
@@ -86,6 +89,7 @@ abstract class AbstractClient
     {
         $this->transport = new HttpTransport();
         $this->socketConfig = $this->newSocketConfig();
+        $this->curlopts = $this->getDefaultCurlOpts();
         $this->useLIVESystem();
         $this->setDefaultLogger();
     }
@@ -236,6 +240,44 @@ abstract class AbstractClient
             $this->ua = "PHP-SDK (" . PHP_OS . "; " . php_uname("m") . "; rv:" . $this->getVersion() . ") php/" . implode(".", [PHP_MAJOR_VERSION, PHP_MINOR_VERSION, PHP_RELEASE_VERSION]);
         }
         return $this->ua;
+    }
+
+    /**
+     * Brand-default cURL options for this client, used to seed and to reset the
+     * live {@see $curlopts} bag. The base client has none; brands that carry a
+     * mandatory transport setting (e.g. IBS/Moniker forcing IPv4 resolution)
+     * override this. Kept separate from the live bag so {@see resetCurlOptions()}
+     * can restore the defaults instead of wiping them.
+     * @return array<int, mixed>
+     */
+    protected function getDefaultCurlOpts(): array
+    {
+        return [];
+    }
+
+    /**
+     * Merge additional cURL options into the live bag, overriding existing
+     * values on key collision (including brand defaults). Use
+     * {@see resetCurlOptions()} to restore the brand defaults afterwards.
+     * @param array<int, mixed> $opts cURL options keyed by CURLOPT_* constant
+     */
+    public function setExtraCurlOptions(array $opts): static
+    {
+        $this->curlopts = $opts + $this->curlopts;
+        return $this;
+    }
+
+    /**
+     * Restore the live cURL options bag to the brand defaults
+     * ({@see getDefaultCurlOpts()}), discarding any options previously set via
+     * {@see setExtraCurlOptions()}/{@see setProxy()}/{@see setReferer()}. Does
+     * NOT clear the bag to an empty array — brand-mandatory options (e.g.
+     * IBS/Moniker's IPv4 resolution) are preserved.
+     */
+    public function resetCurlOptions(): static
+    {
+        $this->curlopts = $this->getDefaultCurlOpts();
+        return $this;
     }
 
     /**

--- a/src/IBS/Client.php
+++ b/src/IBS/Client.php
@@ -25,11 +25,15 @@ class Client extends AbstractClient
 {
     /**
      * Brand-mandatory cURL options. IBS/Moniker force IPv4 resolution
-     * ({@see CURLOPT_IPRESOLVE}); merged over the transport defaults by
-     * {@see \CNIC\AbstractClient::executeCurl()}.
-     * @var array<int, mixed>
+     * ({@see CURLOPT_IPRESOLVE}); this seeds the live {@see \CNIC\AbstractClient::$curlopts}
+     * bag and is restored by {@see \CNIC\AbstractClient::resetCurlOptions()}.
+     * @return array<int, mixed>
      */
-    protected array $curlopts = [CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4];
+    #[\Override]
+    protected function getDefaultCurlOpts(): array
+    {
+        return [CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4];
+    }
 
     /**
      * Instantiate IBS SocketConfig

--- a/tests/AbstractClientCurlOptionsTest.php
+++ b/tests/AbstractClientCurlOptionsTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * CNIC
+ * Copyright © Team Internet Group PLC
+ */
+
+namespace CNICTEST;
+
+use CNIC\AbstractClient;
+use CNIC\ClientFactory as CF;
+use CNIC\CNR\Client as CNRClient;
+use CNIC\IBS\Client as IBSClient;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for the per-client cURL option tuning on AbstractClient
+ * (RSRMID-2913): setExtraCurlOptions() / resetCurlOptions().
+ *
+ * These run without any live API — they only mutate and introspect the
+ * protected $curlopts bag. The bag is read back via reflection (the same
+ * pattern used by AbstractClientIDNTest) so the tests do not depend on the
+ * key-specific getProxy()/getReferer() accessors alone.
+ */
+final class AbstractClientCurlOptionsTest extends TestCase
+{
+    private function cnr(): CNRClient
+    {
+        $cl = CF::getClient("CNR");
+        \assert($cl instanceof CNRClient);
+        return $cl;
+    }
+
+    private function ibs(): IBSClient
+    {
+        $cl = CF::getClient("IBS");
+        \assert($cl instanceof IBSClient);
+        return $cl;
+    }
+
+    /**
+     * Read the protected $curlopts bag off a client.
+     * @return array<int, mixed>
+     */
+    private function curlopts(AbstractClient $cl): array
+    {
+        $p = new \ReflectionProperty($cl, "curlopts");
+        $p->setAccessible(true);
+        /** @var array<int, mixed> $opts */
+        $opts = $p->getValue($cl);
+        return $opts;
+    }
+
+    public function testCnrDefaultCurlOptsIsEmpty(): void
+    {
+        $this->assertSame([], $this->curlopts($this->cnr()));
+    }
+
+    public function testIbsDefaultCurlOptsForcesIpv4(): void
+    {
+        $this->assertSame(
+            [CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4],
+            $this->curlopts($this->ibs())
+        );
+    }
+
+    public function testSetExtraCurlOptionsMergesOverTheBag(): void
+    {
+        $cl = $this->cnr();
+        $cl->setExtraCurlOptions([CURLOPT_TIMEOUT => 5, CURLOPT_PROXY => "10.0.0.1"]);
+
+        // merged into the live bag and observable via the key-specific getter
+        $this->assertSame("10.0.0.1", $cl->getProxy());
+        $this->assertSame(5, $this->curlopts($cl)[CURLOPT_TIMEOUT]);
+
+        // a later call merges, overriding only the colliding keys
+        $cl->setExtraCurlOptions([CURLOPT_TIMEOUT => 9]);
+        $this->assertSame(9, $this->curlopts($cl)[CURLOPT_TIMEOUT]);
+        $this->assertSame("10.0.0.1", $cl->getProxy());
+    }
+
+    public function testSetExtraCurlOptionsUserValueWinsOverBrandDefault(): void
+    {
+        $cl = $this->ibs();
+        $cl->setExtraCurlOptions([CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V6]);
+        $this->assertSame(CURL_IPRESOLVE_V6, $this->curlopts($cl)[CURLOPT_IPRESOLVE]);
+    }
+
+    public function testSetExtraCurlOptionsIsFluent(): void
+    {
+        $cl = $this->cnr();
+        $this->assertSame($cl, $cl->setExtraCurlOptions([CURLOPT_TIMEOUT => 3]));
+    }
+
+    public function testResetCurlOptionsRestoresCnrEmptyDefault(): void
+    {
+        $cl = $this->cnr();
+        $cl->setExtraCurlOptions([CURLOPT_TIMEOUT => 5])->setProxy("127.0.0.1");
+        $cl->resetCurlOptions();
+        $this->assertSame([], $this->curlopts($cl));
+        $this->assertNull($cl->getProxy());
+    }
+
+    public function testResetCurlOptionsPreservesIbsForcedIpv4(): void
+    {
+        $cl = $this->ibs();
+        $cl->setExtraCurlOptions([CURLOPT_TIMEOUT => 5, CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V6]);
+        $cl->resetCurlOptions();
+
+        // reset restores the brand default — it must NOT wipe the bag to []
+        // and silently drop IBS/Moniker's mandatory IPv4 resolution.
+        $this->assertSame(
+            [CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4],
+            $this->curlopts($cl)
+        );
+    }
+
+    public function testResetCurlOptionsIsFluent(): void
+    {
+        $cl = $this->ibs();
+        $this->assertSame($cl, $cl->resetCurlOptions());
+    }
+}


### PR DESCRIPTION
## Summary

Adds a public per-client cURL tuning API to `AbstractClient` — the releasing `feat(client)` follow-up to the RSRMID-2909 request()-template-method refactor (which deliberately kept these non-public to stay a non-releasing `refactor`).

- **`setExtraCurlOptions(array $opts): static`** — merges user cURL options into the live `$curlopts` bag, overriding on key collision (user wins, including brand defaults — an explicit, reset-recoverable escape hatch).
- **`resetCurlOptions(): static`** — restores the live bag to the **brand defaults** rather than wiping it to `[]`, so IBS/Moniker keep their mandatory `CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4` and can't silently fall back to IPv6.
- **`getDefaultCurlOpts()`** — new protected hook = the brand-default source of truth, kept separate from the live bag; the constructor seeds `$curlopts` from it. `IBS\Client` now overrides this hook instead of the `$curlopts` property.

## Testing

- New `tests/AbstractClientCurlOptionsTest.php` (8 tests, no live API — introspects `$curlopts` via reflection like `AbstractClientIDNTest`).
- PHPStan L9, Psalm L1, phpcs PSR-12 all clean; full suite green; `demo:cnr/ibs/moniker` smoke ok.

## Notes

- New public API → **minor** version bump (releasing).
- Follow-up cleanup that removes the IBS IPv4 default as a breaking change is tracked in RSRMID-2915 (this setter is its first step).

Jira: https://centralnic.atlassian.net/browse/RSRMID-2913

🤖 Generated with [Claude Code](https://claude.com/claude-code)