### PR TITLE
docs(history): strip bogus issue references from the changelog

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,10 @@ docs/
 build/
 pnpm-lock.yaml
 *.php
+
+# Generated and owned by semantic-release (@semantic-release/changelog), which
+# commits it through @semantic-release/git and therefore never passes it through
+# lint-staged. So the copy in git is unformatted, and any human commit that
+# touches the file made lint-staged's "**/*" rule reflow the whole changelog —
+# 500 lines of churn to edit two. Left alone instead.
+HISTORY.md

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,7 +3,7 @@
 
 ### Features
 
-* **config:** give connection configuration one home on the SocketConfig ([e3bb8ae](https://github.com/centralnicgroup-opensource/rtldev-middleware-php-sdk/commit/e3bb8ae2d626afa1991c6a379809195feb3e1feb)), closes [hi#performance](https://github.com/hi/issues/performance) [Hi#performance](https://github.com/Hi/issues/performance)
+* **config:** give connection configuration one home on the SocketConfig ([e3bb8ae](https://github.com/centralnicgroup-opensource/rtldev-middleware-php-sdk/commit/e3bb8ae2d626afa1991c6a379809195feb3e1feb))
 
 
 ### BREAKING CHANGES
@@ -213,7 +213,7 @@ clamped value must switch to hasNextPage() or handle the null sentinel.
 
 ### Bug Fixes
 
-* **client:** scope high-performance URL rewrite to host and scheme ([b16f3df](https://github.com/centralnicgroup-opensource/rtldev-middleware-php-sdk/commit/b16f3dfcb4e9dfa4653955924559ab036c13c385)), closes [hi#performance](https://github.com/hi/issues/performance)
+* **client:** scope high-performance URL rewrite to host and scheme ([b16f3df](https://github.com/centralnicgroup-opensource/rtldev-middleware-php-sdk/commit/b16f3dfcb4e9dfa4653955924559ab036c13c385))
 * **http:** reset reused cURL handle per call to stop option leakage ([8ec9f92](https://github.com/centralnicgroup-opensource/rtldev-middleware-php-sdk/commit/8ec9f92c66d2520c42c0bd6533cc5f47fae834fa))
 * **ibs:** compute getLastRecordIndex per-instance and harden status access ([cb5a177](https://github.com/centralnicgroup-opensource/rtldev-middleware-php-sdk/commit/cb5a177de62dec48acd7ae640e69c65132935c0e))
 * **translator:** preserve full cURL error text containing a pipe ([fa44c9f](https://github.com/centralnicgroup-opensource/rtldev-middleware-php-sdk/commit/fa44c9ff2ce605fb8ee1419d4f64262ba28c1346))


### PR DESCRIPTION
## Jira

Follow-up to [RSRMID-2921](https://centralnic.atlassian.net/browse/RSRMID-2921) (already Done) — cosmetic fallout in the generated changelog, no `src/` change. `docs` type, so non-releasing.

## What

Two `HISTORY.md` entries carried dead `closes` links to `github.com/hi/issues/performance`:

- the v23.0.0 config entry (`e3bb8ae`)
- the v19.1.1 high-performance URL fix (`b16f3df`)

Neither commit referenced an issue. **The trigger is the literal substring `gh-` inside "hi`gh-`performance"**: the conventional-commits parser reads it as an issue prefix and splits `hi | gh- | performance` into owner `hi` and issue `performance`, which the writer renders as `hi#performance` with a GitHub URL built around it. The v23.0.0 entry got two because the same substring also appears capitalised at the start of a sentence in that commit body.

Editing `HISTORY.md` by hand is safe: `@semantic-release/changelog` only ever prepends new sections and never rewrites past ones.

## Also: `HISTORY.md` added to `.prettierignore`

Not scope creep — it is why this change is reviewable. `HISTORY.md` is generated by `@semantic-release/changelog` and committed through `@semantic-release/git`, which bypasses `lint-staged`. The copy in git is therefore unformatted, so the `"**/*": ["prettier --write"]` rule reflows the **entire** changelog the moment a human commit touches it. The first attempt at this two-line edit produced a 500-line diff (190 insertions / 310 deletions). With the ignore entry it is 2 lines, as it should be, and the next person to correct an entry will not hit the same wall.

## Deliberately not changed

The parser's `referenceActions` / `issuePrefixes` are left at their defaults in `.releaserc.json`. Disabling reference parsing would stop this recurring, but it would also drop legitimate links — `closes #40` in the v6.0.2 entry is the only real reference in the file, and it survives here. The cheap habit is to avoid the hyphenated spelling in commit subjects and bodies: "high performance" yields no reference at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[RSRMID-2921]: https://centralnic.atlassian.net/browse/RSRMID-2921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ