### PR TITLE
refactor(src): name internal parameters so the annotation restating them can go

### DIFF
--- a/src/AbstractClient.php
+++ b/src/AbstractClient.php
@@ -175,7 +175,6 @@ abstract class AbstractClient
      * Instantiate the brand Response for the given raw payload.
      * Return type is covariant so each brand pins its concrete Response.
      *
-     * @param string $raw raw API response payload
      * @param array<string, string> $cmd flattened command that produced the response
      * @param array{CONNECTION_URL: string} $cfg connection config used for the request
      */
@@ -481,16 +480,15 @@ abstract class AbstractClient
      * a way for a subclass to put a second answer behind `getProxy()`. A
      * per-request option belongs on the config before the request, or on a
      * transport the caller drives themselves.
-     * @param string $data serialized POST payload
      * @param array{CONNECTION_URL: string} $cfg connection config
      * @return array{0: string, 1: string|null} [rawResponse, errorMessage|null]
      * @throws UnsupportedFeatureException if a transport-owned option was set
      */
-    protected function executeCurl(string $data, array $cfg): array
+    protected function executeCurl(string $postData, array $cfg): array
     {
         return $this->transport->post(
             $cfg["CONNECTION_URL"],
-            $data,
+            $postData,
             $this->socketConfig->getSocketTimeout(),
             $this->getUserAgent(),
             $this->socketConfig->getCurlOptions()

--- a/src/AbstractResponseTranslator.php
+++ b/src/AbstractResponseTranslator.php
@@ -130,12 +130,11 @@ abstract class AbstractResponseTranslator
      * This function searches for a specified regular expression pattern in the provided text and
      * performs replacements based on the matched pattern, command data, and placeholder values.
      *
-     * @param string $regex The regular expression pattern to search for.
-     * @param string $newraw The input text where the match will be searched for and replacements applied.
-     * @param string $val The value to be used in replacement if a match is found.
+     * $subject is mutated in place when a replacement is applied.
+     *
      * @param array<string, string> $cmd The command data containing replacements, if applicable.
      */
-    private static function findMatch(string $regex, string &$newraw, string $val, array $cmd): bool
+    private static function findMatch(string $regex, string &$subject, string $replacement, array $cmd): bool
     {
         // match the response for given description
         // NOTE: we match if the description starts with the given description
@@ -144,16 +143,14 @@ abstract class AbstractResponseTranslator
         $qregex = "/" . $field . "\s*=\s*" . $regex . "([^\\r\\n]+)?/i";
         $return = false;
 
-        if (preg_match($qregex, $newraw)) {
-            // If "COMMAND" exists in $cmd, replace "{COMMAND}" in $val
+        if (preg_match($qregex, $subject)) {
             if (isset($cmd["COMMAND"])) {
-                $val = str_replace("{COMMAND}", $cmd["COMMAND"], $val);
+                $replacement = str_replace("{COMMAND}", $cmd["COMMAND"], $replacement);
             }
 
-            // If $newraw matches $qregex, replace with "<field>=" . $val
-            $tmp = preg_replace($qregex, $field . "=" . $val, $newraw);
-            if ($tmp !== null && $tmp !== $newraw) {
-                $newraw = $tmp;
+            $tmp = preg_replace($qregex, $field . "=" . $replacement, $subject);
+            if ($tmp !== null && $tmp !== $subject) {
+                $subject = $tmp;
                 $return = true;
             }
         }
@@ -169,7 +166,6 @@ abstract class AbstractResponseTranslator
      * placeholders are substituted, unknown {UPPER} tokens are stripped, and any
      * other brace content (e.g. lowercase %{i} in SPF records) is left untouched.
      *
-     * @param string $raw input response
      * @param array{CONNECTION_URL?: string} $ph placeholder key-value pairs
      */
     protected static function replacePlaceholders(string $raw, array $ph): string

--- a/src/CNR/Client.php
+++ b/src/CNR/Client.php
@@ -145,7 +145,6 @@ class Client extends AbstractClient implements RoleCredentialsInterface
 
     /**
      * Instantiate a CNR Response for the given raw payload.
-     * @param string $raw raw API response payload
      * @param array<string, string> $cmd flattened command that produced the response
      * @param array{CONNECTION_URL: string} $cfg connection config used for the request
      */

--- a/src/CommandFormatter.php
+++ b/src/CommandFormatter.php
@@ -168,7 +168,6 @@ final class CommandFormatter
     /**
      * Find the priority of a given key
      *
-     * @param string $key The key to find the priority for
      * @param array<string,int> $priority The priority array
      */
     private static function findPriority(string $key, array $priority): int

--- a/src/IBS/Client.php
+++ b/src/IBS/Client.php
@@ -87,7 +87,6 @@ class Client extends AbstractClient
 
     /**
      * Instantiate an IBS Response for the given raw payload.
-     * @param string $raw raw API response payload
      * @param array<string, string> $cmd flattened command that produced the response
      * @param array{CONNECTION_URL: string} $cfg connection config used for the request
      */


### PR DESCRIPTION
Jira: [RSRMID-2934](https://centralnic.atlassian.net/browse/RSRMID-2934)

Closes the last piece of the token-cost review of the docs and source docblocks. The two larger halves of that work went straight to `master` (`39eed63` docs, `7b3f7b0` src docblocks); this branch carries the parameter renames, which are a code change and so get a PR.

## What this does

Where a parameter name carries its own meaning, the `@param` line describing it is a second copy that can drift. This renames the internal parameters where that applies and drops the nine annotations they made redundant.

- `AbstractResponseTranslator::findMatch()`: `$newraw` → `$subject` (it is the by-ref subject of the replacement), `$val` → `$replacement`. Three annotations go, plus two inline comments that restated the line below them. What a name cannot carry is kept: that `$subject` is mutated in place.
- `AbstractClient::executeCurl()`: `$data` → `$postData`.
- The redundant `@param string $raw raw API response payload` on the three `newResponse()` hooks, whose summary already says "for the given raw payload", and `CommandFormatter::findPriority()`'s `@param string $key The key to find the priority for` under the summary "Find the priority of a given key".

## Why the scope stops at private/protected

A public parameter name is part of the API surface under PHP 8 named arguments. Verified rather than assumed — this works against the SDK today, both on the concrete class and through the interface consumers are told to type against:

```php
$r->getColumn(key: "DOMAIN");
fn (\CNIC\ResponseInterface $r) => $r->getColumn(key: "DOMAIN");
```

Rename the parameter and that consumer gets `Error: Unknown named parameter $key` — at runtime, with a message that does not point at an SDK upgrade. PHP has no parameter alias, so there is no soft-migration path. That half is breaking, needs a major bump, and is tracked in its own issue to be batched with the next breaking change.

Two parameters that looked eligible were left alone on purpose: `$secured` on the `getPOSTDataParams()`/`getPOSTData()` pair and `$key` on `Record`'s private helper each have a public twin of the same name, and renaming only the internal one would make the two diverge for no reader's benefit. They go with the public batch.

## Verification

- Comments and parameter names only — non-comment, non-blank lines in `src/` are **2354 before and after**.
- `composer lint` clean (prettier, phpcs, phpstan L9, psalm L1, shellcheck). PHPStan is what would catch a half-done rename: it reports `argument.parameterRenamedInSubtype` if an interface and its implementation disagree.
- 579 tests pass, 1 pre-existing skip (the CNR failed-login test, skipped upstream because CNR temp-bans on failed login attempts).
- `refactor` type, so no release is triggered.


[RSRMID-2934]: https://centralnic.atlassian.net/browse/RSRMID-2934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ