### PR TITLE
build(deps): upgrade idn-converter to ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
   "require": {
     "php": ">=8.3.0",
     "ext-curl": "*",
-    "centralnic-reseller/idn-converter": "^1.0"
+    "centralnic-reseller/idn-converter": "^2.0"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,28 +4,35 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ce2a6ad6acd64f86e747ddceba28b204",
+    "content-hash": "042229c020bc6a437fdba594770e0097",
     "packages": [
         {
             "name": "centralnic-reseller/idn-converter",
-            "version": "v1.0.5",
+            "version": "v2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/centralnicgroup-opensource/rtldev-middleware-php-idna-translator.git",
-                "reference": "149017db1279f509f4d80c3fa7e73cc6794f8143"
+                "reference": "1175a59427b04c8be1be2e981c6a6d51fa45d3b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/centralnicgroup-opensource/rtldev-middleware-php-idna-translator/zipball/149017db1279f509f4d80c3fa7e73cc6794f8143",
-                "reference": "149017db1279f509f4d80c3fa7e73cc6794f8143",
+                "url": "https://api.github.com/repos/centralnicgroup-opensource/rtldev-middleware-php-idna-translator/zipball/1175a59427b04c8be1be2e981c6a6d51fa45d3b0",
+                "reference": "1175a59427b04c8be1be2e981c6a6d51fa45d3b0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4.0"
+                "ext-intl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": "^8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0",
-                "squizlabs/php_codesniffer": "^3.9 || ^4.0"
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^11.0",
+                "rector/rector": "^2.0",
+                "slevomat/coding-standard": "^8.0",
+                "squizlabs/php_codesniffer": "^3.9 || ^4.0",
+                "vimeo/psalm": "^6.0"
             },
             "type": "library",
             "extra": {
@@ -56,9 +63,9 @@
             ],
             "support": {
                 "issues": "https://github.com/centralnicgroup-opensource/rtldev-middleware-php-idna-translator/issues",
-                "source": "https://github.com/centralnicgroup-opensource/rtldev-middleware-php-idna-translator/tree/v1.0.5"
+                "source": "https://github.com/centralnicgroup-opensource/rtldev-middleware-php-idna-translator/tree/v2.0.0"
             },
-            "time": "2026-05-28T12:25:22+00:00"
+            "time": "2026-07-02T16:43:56+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
Upgrades the direct dependency `centralnic-reseller/idn-converter` from `^1.0` (v1.0.5) to `^2.0` (v2.0.0).

## Why no code changes

v2.0.0's [only breaking change](https://github.com/centralnicgroup-opensource/rtldev-middleware-php-idna-translator/blob/master/HISTORY.md) is the PHP floor moving 7.4 → 8.3. This SDK already requires `>=8.3.0`, so there is nothing to reconcile.

`ConverterFactory::convert(string|array $keywords, array $options = []): array` is unchanged, and the `array{idn: string|false, punycode: string|false}` return shape still matches the `@var` annotations at both call sites:

- `AbstractClient::convertIDN()` (`src/AbstractClient.php`)
- `CNR\IDNCommandRewriter` (`src/CNR/IDNCommandRewriter.php`)

## Why `build(deps)` and not `fix`/`feat`

No `src/` change, no behaviour change, and no consumer-visible PHP floor change — a release would deliver nothing today. The widened constraint ships with the next `fix`/`feat` release, which is what actually moves consumers off the now-unmaintained v1 line.

Worth knowing: `composer.json` is one of the four files in the Packagist dist, so until a release goes out every downstream project still resolves `^1.0` and installs v1.0.5.

## Constraint narrowed to `^2.0`

Deliberately `^2.0` rather than `^1.0 || ^2.0` — keeping v1 resolvable buys nothing given the identical API and the 8.3 floor every consumer already meets. Not treated as a breaking change, so no `MIGRATION.md` section.

## Verification

- `composer test` — 630 passed, 1 skipped, 1677 assertions (the skip is the loopback-port functional test)
- `composer lint` — exit 0: prettier, phpcs, PHPStan L9, Psalm L1, shellcheck all clean
- `composer validate` — valid, lock content-hash in sync
- `composer audit` — no advisories

## Jira

No `RSRMID` ticket exists for this bump, so the branch carries no Jira prefix and there is no issue link. Happy to open one and link it if you'd rather it be tracked.
